### PR TITLE
Update Memgraph base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM memgraph:latest AS memgraph-mage
+FROM memgraph/memgraph:latest AS memgraph-mage
 
 FROM memgraph-mage
 USER root


### PR DESCRIPTION
Since Memgraph is in DockerHub now, this should be updated.