### PR TITLE
Fix betweenness centrality algorithm name typo

### DIFF
--- a/cpp/betweenness_centrality_module/betweenness_centrality_module.cpp
+++ b/cpp/betweenness_centrality_module/betweenness_centrality_module.cpp
@@ -7,7 +7,7 @@
 
 namespace {
 
-constexpr char const *kFieldBCScore = "betweeenness_centrality";
+constexpr char const *kFieldBCScore = "betweenness_centrality";
 constexpr char const *kFieldNode = "node";
 
 constexpr char const *kArgumentDirected = "directed";
@@ -15,13 +15,13 @@ constexpr char const *kArgumentNormalized = "normalized";
 constexpr char const *kArgumentThreads = "threads";
 
 void InsertBCRecord(const mgp_graph *graph, mgp_result *result, mgp_memory *memory,
-                    const double betweeenness_centrality, const int node_id) {
+                    const double betweenness_centrality, const int node_id) {
   auto *record = mgp_result_new_record(result);
   if (record == nullptr) {
     throw mg_exception::NotEnoughMemoryException();
   }
   mg_utility::InsertNodeValueResult(graph, record, kFieldNode, node_id, memory);
-  mg_utility::InsertDoubleValue(record, kFieldBCScore, betweeenness_centrality, memory);
+  mg_utility::InsertDoubleValue(record, kFieldBCScore, betweenness_centrality, memory);
 }
 
 void GetBetweennessCentrality(const mgp_list *args, const mgp_graph *memgraph_graph, mgp_result *result,

--- a/e2e/betweenness_centrality_test/test_chain_directed/test.yml
+++ b/e2e/betweenness_centrality_test/test_chain_directed/test.yml
@@ -1,16 +1,16 @@
 query: >
     CALL betweenness_centrality.get(TRUE,FALSE)
-    YIELD node, betweeenness_centrality
-    RETURN betweeenness_centrality, node.id AS node_id;
+    YIELD node, betweenness_centrality
+    RETURN betweenness_centrality, node.id AS node_id;
 
 output:
-- betweeenness_centrality: 0
+- betweenness_centrality: 0
   node_id: 0
-- betweeenness_centrality: 3
+- betweenness_centrality: 3
   node_id: 1
-- betweeenness_centrality: 4
+- betweenness_centrality: 4
   node_id: 2
-- betweeenness_centrality: 3
+- betweenness_centrality: 3
   node_id: 3
-- betweeenness_centrality: 0
+- betweenness_centrality: 0
   node_id: 4

--- a/e2e/betweenness_centrality_test/test_chain_normalized/test.yml
+++ b/e2e/betweenness_centrality_test/test_chain_normalized/test.yml
@@ -1,16 +1,16 @@
 query: >
     CALL betweenness_centrality.get(FALSE,TRUE)
-    YIELD node, betweeenness_centrality
-    RETURN betweeenness_centrality, node.id AS node_id;
+    YIELD node, betweenness_centrality
+    RETURN betweenness_centrality, node.id AS node_id;
 
 output:
-- betweeenness_centrality: 0
+- betweenness_centrality: 0
   node_id: 0
-- betweeenness_centrality: 0.5
+- betweenness_centrality: 0.5
   node_id: 1
-- betweeenness_centrality: 0.6666666666666666
+- betweenness_centrality: 0.6666666666666666
   node_id: 2
-- betweeenness_centrality: 0.5
+- betweenness_centrality: 0.5
   node_id: 3
-- betweeenness_centrality: 0
+- betweenness_centrality: 0
   node_id: 4

--- a/e2e/betweenness_centrality_test/test_chain_undirected/test.yml
+++ b/e2e/betweenness_centrality_test/test_chain_undirected/test.yml
@@ -1,16 +1,16 @@
 query: >
     CALL betweenness_centrality.get(FALSE,FALSE)
-    YIELD node, betweeenness_centrality
-    RETURN betweeenness_centrality, node.id AS node_id;
+    YIELD node, betweenness_centrality
+    RETURN betweenness_centrality, node.id AS node_id;
 
 output:
-- betweeenness_centrality: 0
+- betweenness_centrality: 0
   node_id: 0
-- betweeenness_centrality: 3
+- betweenness_centrality: 3
   node_id: 1
-- betweeenness_centrality: 4
+- betweenness_centrality: 4
   node_id: 2
-- betweeenness_centrality: 3
+- betweenness_centrality: 3
   node_id: 3
-- betweeenness_centrality: 0
+- betweenness_centrality: 0
   node_id: 4

--- a/e2e/betweenness_centrality_test/test_complete_graph/test.yml
+++ b/e2e/betweenness_centrality_test/test_complete_graph/test.yml
@@ -1,16 +1,16 @@
 query: >
     CALL betweenness_centrality.get(FALSE,FALSE)
-    YIELD node, betweeenness_centrality
-    RETURN betweeenness_centrality, node.id AS node_id;
+    YIELD node, betweenness_centrality
+    RETURN betweenness_centrality, node.id AS node_id;
 
 output:
-- betweeenness_centrality: 0
+- betweenness_centrality: 0
   node_id: 0
-- betweeenness_centrality: 0
+- betweenness_centrality: 0
   node_id: 1
-- betweeenness_centrality: 0
+- betweenness_centrality: 0
   node_id: 2
-- betweeenness_centrality: 0
+- betweenness_centrality: 0
   node_id: 3
-- betweeenness_centrality: 0
+- betweenness_centrality: 0
   node_id: 4

--- a/e2e/betweenness_centrality_test/test_empty/test.yml
+++ b/e2e/betweenness_centrality_test/test_empty/test.yml
@@ -1,6 +1,6 @@
 query: >
     CALL betweenness_centrality.get(FALSE,FALSE)
-    YIELD node, betweeenness_centrality
-    RETURN betweeenness_centrality, node.id AS node_id;
+    YIELD node, betweenness_centrality
+    RETURN betweenness_centrality, node.id AS node_id;
 
 output: []

--- a/e2e/betweenness_centrality_test/test_normalized_directed_graph/test.yml
+++ b/e2e/betweenness_centrality_test/test_normalized_directed_graph/test.yml
@@ -1,16 +1,16 @@
 query: >
     CALL betweenness_centrality.get(TRUE,TRUE)
-    YIELD node, betweeenness_centrality
-    RETURN betweeenness_centrality, node.id AS node_id;
+    YIELD node, betweenness_centrality
+    RETURN betweenness_centrality, node.id AS node_id;
 
 output:
-- betweeenness_centrality: 0
+- betweenness_centrality: 0
   node_id: 0
-- betweeenness_centrality: 0.08333333333333333
+- betweenness_centrality: 0.08333333333333333
   node_id: 1
-- betweeenness_centrality: 0.16666666666666666
+- betweenness_centrality: 0.16666666666666666
   node_id: 2
-- betweeenness_centrality: 0.16666666666666666
+- betweenness_centrality: 0.16666666666666666
   node_id: 3
-- betweeenness_centrality: 0.3333333333333333
+- betweenness_centrality: 0.3333333333333333
   node_id: 4

--- a/e2e/betweenness_centrality_test/test_two_nodes/test.yml
+++ b/e2e/betweenness_centrality_test/test_two_nodes/test.yml
@@ -1,11 +1,11 @@
 query: >
     CALL betweenness_centrality.get(FALSE,TRUE)
-    YIELD node, betweeenness_centrality
-    RETURN betweeenness_centrality, node.id AS node_id;
+    YIELD node, betweenness_centrality
+    RETURN betweenness_centrality, node.id AS node_id;
 
 output:
-- betweeenness_centrality: 0
+- betweenness_centrality: 0
   node_id: 0
-- betweeenness_centrality: 0
+- betweenness_centrality: 0
   node_id: 1
 


### PR DESCRIPTION
Return value was called `betweeenness_centrality` which has a typo

Closes #59 