### PR TITLE
Fix memory leakage

### DIFF
--- a/cpp/mg_utility/mg_utils.hpp
+++ b/cpp/mg_utility/mg_utils.hpp
@@ -101,9 +101,6 @@ std::unique_ptr<mg_graph::Graph<TSize>> GetGraphView(mgp_graph *memgraph_graph, 
   // Safe creation of vertices iterator
 
   auto *vertices_it = mgp::graph_iter_vertices(memgraph_graph, memory);
-  if (vertices_it == nullptr) {
-    throw mg_exception::NotEnoughMemoryException();
-  }
   mg_utility::OnScopeExit delete_vertices_it([&vertices_it] { mgp::vertices_iterator_destroy(vertices_it); });
 
   // Iterate trough Memgraph vertices and map them to GraphView
@@ -111,6 +108,8 @@ std::unique_ptr<mg_graph::Graph<TSize>> GetGraphView(mgp_graph *memgraph_graph, 
        vertex = mgp::vertices_iterator_next(vertices_it)) {
     mg_graph::CreateGraphNode(graph.get(), vertex);
   }
+  // Destroy iterator before creating a new one - otherwise, we'll experience memory leakage
+  mgp::vertices_iterator_destroy(vertices_it);
 
   ///
   /// Mapping Memgraph in-memory edges into graph view


### PR DESCRIPTION
Once the iterator's reference is changed, we should destroy the iterator instance. 