### PR TITLE
Change workflow trigger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ env:
   CORE_COUNT: '8'
   MAGE_CONTAINER: 'mage'
 
-on: [push]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
In order to run CI jobs from the forked PRsworkflow trigger, the configuration needs to change to `pull_request`. And only then with one of the maintainer's approval the jobs will run.