### PR TITLE
Clarify InsertDoubleValueResult inserts results

### DIFF
--- a/cpp/betweenness_centrality_module/betweenness_centrality_module.cpp
+++ b/cpp/betweenness_centrality_module/betweenness_centrality_module.cpp
@@ -20,7 +20,7 @@ void InsertBCRecord(mgp_graph *graph, mgp_result *result, mgp_memory *memory, co
   auto *record = mgp::result_new_record(result);
 
   mg_utility::InsertNodeValueResult(graph, record, kFieldNode, node_id, memory);
-  mg_utility::InsertDoubleValue(record, kFieldBCScore, betweenness_centrality, memory);
+  mg_utility::InsertDoubleValueResult(record, kFieldBCScore, betweenness_centrality, memory);
 }
 
 void GetBetweennessCentrality(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory) {

--- a/cpp/mg_utility/mg_utils.hpp
+++ b/cpp/mg_utility/mg_utils.hpp
@@ -158,7 +158,7 @@ void InsertIntValueResult(mgp_result_record *record, const char *field_name, con
 
 /// Inserts a double of value double_value to the field field_name of
 /// the record mgp_result_record record.
-void InsertDoubleValue(mgp_result_record *record, const char *field_name, const double double_value,
+void InsertDoubleValueResult(mgp_result_record *record, const char *field_name, const double double_value,
                        mgp_memory *memory) {
   auto value = mgp::value_make_double(double_value, memory);
   InsertRecord(record, field_name, value);

--- a/cpp/pagerank_module/pagerank_module.cpp
+++ b/cpp/pagerank_module/pagerank_module.cpp
@@ -17,7 +17,7 @@ void InsertPagerankRecord(mgp_graph *graph, mgp_result *result, mgp_memory *memo
   auto *record = mgp::result_new_record(result);
 
   mg_utility::InsertNodeValueResult(graph, record, kFieldNode, node_id, memory);
-  mg_utility::InsertDoubleValue(record, kFieldRank, rank, memory);
+  mg_utility::InsertDoubleValueResult(record, kFieldRank, rank, memory);
 }
 
 /// Memgraph query module implementation of parallel pagerank_module algorithm.

--- a/cpp/pagerank_module/pagerank_online_module.cpp
+++ b/cpp/pagerank_module/pagerank_online_module.cpp
@@ -25,7 +25,7 @@ void InsertPagerankRecord(mgp_graph *graph, mgp_result *result, mgp_memory *memo
   auto *record = mgp::result_new_record(result);
 
   mg_utility::InsertNodeValueResult(graph, record, kFieldNode, node_id, memory);
-  mg_utility::InsertDoubleValue(record, kFieldRank, rank, memory);
+  mg_utility::InsertDoubleValueResult(record, kFieldRank, rank, memory);
 }
 
 void InsertMessageRecord(mgp_result *result, mgp_memory *memory, const char *message) {


### PR DESCRIPTION
Closes #96

`mg_utility` methods for inserting results follow the Insert{TYPE}ValueResult pattern, e.g. `InsertBoolValueResult`.
This PR renames `InsertDoubleValue` to ``InsertDoubleValueResult` to bring it in line with this.

