### PR TITLE
Add test build on different platforms

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,11 +91,20 @@ jobs:
           python -m pytest .
 
   build-and-test-windows:
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        os: [ windows-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
       - uses: Vampire/setup-wsl@v1
+        with:
+          distribution: Ubuntu-20.04
 
       - name: Build Memgraph MAGE:prod and MAGE:dev images
+        shell: wsl-bash {0} # root shell
         run: |
           docker build . -t memgraph-mage:prod --target prod
           docker build . -t memgraph-mage:dev --target dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,12 @@ on: [pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ macos-latest, windows-latest, ubuntu-20.04 ]
+      max-parallel: 3
+      fail-fast: true
     - uses: actions/checkout@v2
 
     - name: Build Memgraph MAGE:prod and MAGE:dev images

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
         os: [ macos-latest, windows-latest, ubuntu-20.04 ]
       max-parallel: 3
       fail-fast: true
+    steps:
     - uses: actions/checkout@v2
 
     - name: Build Memgraph MAGE:prod and MAGE:dev images

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,8 @@ jobs:
           sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable"
           apt-cache policy docker-ce
           sudo apt -y install docker-ce
+          sudo systemctl status docker
+          sudo systemctl start docker
 
           sudo docker build . -t memgraph-mage:prod --target prod
           sudo docker build . -t memgraph-mage:dev --target dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
   build-and-test-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: Vampire/setup-wsl@v1
 
       - name: Build Memgraph MAGE:prod and MAGE:dev images
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
         shell: wsl-bash {0} # root shell
         run: |
           sudo apt update
-          sudo apt install apt-transport-https ca-certificates curl software-properties-common
+          sudo apt -y install apt-transport-https ca-certificates curl software-properties-common
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
           sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable"
           apt-cache policy docker-ce

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,84 +8,194 @@ env:
 on: [pull_request, workflow_dispatch]
 
 jobs:
-  build:
+  build-and-test-linux:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-latest, windows-latest, ubuntu-20.04 ]
-      max-parallel: 3
-      fail-fast: false
+        os: [ ubuntu-18.04, ubuntu-20.04 ]
+      max-parallel: 2
+      fail-fast: true
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Build Memgraph MAGE:prod and MAGE:dev images
-      run: |
-        DOCKER_BUILDKIT=1 docker build . -t memgraph-mage:prod --target prod
-        DOCKER_BUILDKIT=1 docker build . -t memgraph-mage:dev --target dev
+      - name: Build Memgraph MAGE:prod and MAGE:dev images
+        run: |
+          DOCKER_BUILDKIT=1 docker build . -t memgraph-mage:prod --target prod
+          DOCKER_BUILDKIT=1 docker build . -t memgraph-mage:dev --target dev
 
-    - name: Run Memgraph MAGE:prod image
-      run: |
-        docker run -d -p 7687:7687 --name ${{ env.MAGE_CONTAINER }} memgraph-mage:prod --telemetry-enabled=False
+      - name: Run Memgraph MAGE:prod image
+        run: |
+          docker run -d -p 7687:7687 --name ${{ env.MAGE_CONTAINER }} memgraph-mage:prod --telemetry-enabled=False
 
-    - name: Set up C++
-      run: |
-        sudo apt update
-        sudo apt install -y build-essential cmake
+      - name: Set up C++
+        run: |
+          sudo apt update
+          sudo apt install -y build-essential cmake
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ env.PY_VERSION }}
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PY_VERSION }}
 
-    - name: Build C++ modules
-      run: |
-        mkdir -p cpp/build
-        cd cpp/build
-        cmake ..
-        make -j${{ env.CORE_COUNT }}
+      - name: Build C++ modules
+        run: |
+          mkdir -p cpp/build
+          cd cpp/build
+          cmake ..
+          make -j${{ env.CORE_COUNT }}
 
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r ./python/tests/requirements.txt
-        pip install -r ./python/requirements.txt
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ./python/tests/requirements.txt
+          pip install -r ./python/requirements.txt
 
-    - name: Test End-to-end on prod
-      env:
-        PYTHONPATH: '$PWD/e2e'
-      run: |
-        cd e2e
-        python -m pytest .
+      - name: Test End-to-end on prod
+        env:
+          PYTHONPATH: '$PWD/e2e'
+        run: |
+          cd e2e
+          python -m pytest .
 
-    - name: Stop prod mage container and remove it
-      run: |
-        docker stop ${{ env.MAGE_CONTAINER }}
-        docker rm ${{ env.MAGE_CONTAINER }}
+      - name: Stop prod mage container and remove it
+        run: |
+          docker stop ${{ env.MAGE_CONTAINER }}
+          docker rm ${{ env.MAGE_CONTAINER }}
 
-    - name: Run Memgraph MAGE dev image
-      run:  docker run -d -p 7687:7687 --name ${{ env.MAGE_CONTAINER }} memgraph-mage:dev --telemetry-enabled=False
+      - name: Run Memgraph MAGE dev image
+        run: docker run -d -p 7687:7687 --name ${{ env.MAGE_CONTAINER }} memgraph-mage:dev --telemetry-enabled=False
 
-    - name: C++ Modules unit tests
-      run: |
-        cd cpp/build
-        ctest -j${{ env.CORE_COUNT }}
+      - name: C++ Modules unit tests
+        run: |
+          cd cpp/build
+          ctest -j${{ env.CORE_COUNT }}
 
-    - name: Python modules unit tests
-      env:
-        PYTHONPATH: '$PWD/python'
-      run: |
-        cd python
-        python -m pytest .
+      - name: Python modules unit tests
+        env:
+          PYTHONPATH: '$PWD/python'
+        run: |
+          cd python
+          python -m pytest .
 
-    - name: Rust library tests
-      run: |
-        cd rust/rsmgp-sys
-        cargo fmt -- --check
-        cargo test
+      - name: Rust library tests
+        run: |
+          cd rust/rsmgp-sys
+          cargo fmt -- --check
+          cargo test
 
-    - name: Test End-to-end on dev
-      env:
-        PYTHONPATH: '$PWD/e2e'
-      run: |
-        cd e2e
-        python -m pytest .
+      - name: Test End-to-end on dev
+        env:
+          PYTHONPATH: '$PWD/e2e'
+        run: |
+          cd e2e
+          python -m pytest .
+
+  build-and-test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Memgraph MAGE:prod and MAGE:dev images
+        run: |
+          docker build . -t memgraph-mage:prod --target prod
+          docker build . -t memgraph-mage:dev --target dev
+
+      - name: Run Memgraph MAGE:prod image
+        run: |
+          docker run -d -p 7687:7687 --name ${{ env.MAGE_CONTAINER }} memgraph-mage:prod --telemetry-enabled=False
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PY_VERSION }}
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ./python/tests/requirements.txt
+          pip install -r ./python/requirements.txt
+
+      - name: Test End-to-end on prod
+        env:
+          PYTHONPATH: '$PWD/e2e'
+        run: |
+          cd e2e
+          python -m pytest .
+
+      - name: Stop prod mage container and remove it
+        run: |
+          docker stop ${{ env.MAGE_CONTAINER }}
+          docker rm ${{ env.MAGE_CONTAINER }}
+
+      - name: Run Memgraph MAGE dev image
+        run: docker run -d -p 7687:7687 --name ${{ env.MAGE_CONTAINER }} memgraph-mage:dev --telemetry-enabled=False
+
+      - name: Python modules unit tests
+        env:
+          PYTHONPATH: '$PWD/python'
+        run: |
+          cd python
+          python -m pytest .
+
+      - name: Test End-to-end on dev
+        env:
+          PYTHONPATH: '$PWD/e2e'
+        run: |
+          cd e2e
+          python -m pytest .
+
+  build-and-test-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install docker
+        run: |
+            mkdir -p ~/.docker/machine/cache
+            curl -Lo ~/.docker/machine/cache/boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v19.03.12/boot2docker.iso
+            brew install docker docker-machine
+
+      - name: Build Memgraph MAGE:prod and MAGE:dev images
+        run: |
+          docker build . -t memgraph-mage:prod --target prod
+          docker build . -t memgraph-mage:dev --target dev
+
+      - name: Run Memgraph MAGE:prod image
+        run: |
+          docker run -d -p 7687:7687 --name ${{ env.MAGE_CONTAINER }} memgraph-mage:prod --telemetry-enabled=False
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PY_VERSION }}
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ./python/tests/requirements.txt
+          pip install -r ./python/requirements.txt
+
+      - name: Test End-to-end on prod
+        env:
+          PYTHONPATH: '$PWD/e2e'
+        run: |
+          cd e2e
+          python -m pytest .
+
+      - name: Stop prod mage container and remove it
+        run: |
+          docker stop ${{ env.MAGE_CONTAINER }}
+          docker rm ${{ env.MAGE_CONTAINER }}
+
+      - name: Run Memgraph MAGE dev image
+        run: docker run -d -p 7687:7687 --name ${{ env.MAGE_CONTAINER }} memgraph-mage:dev --telemetry-enabled=False
+
+
+      - name: Test End-to-end on dev
+        env:
+          PYTHONPATH: '$PWD/e2e'
+        run: |
+          cd e2e
+          python -m pytest .
+
+
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
           sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable"
           apt-cache policy docker-ce
-          sudo apt install docker-ce
+          sudo apt -y install docker-ce
 
           sudo docker build . -t memgraph-mage:prod --target prod
           sudo docker build . -t memgraph-mage:dev --target dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ macos-latest, windows-latest, ubuntu-20.04 ]
       max-parallel: 3
-      fail-fast: true
+      fail-fast: false
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,8 +106,15 @@ jobs:
       - name: Build Memgraph MAGE:prod and MAGE:dev images
         shell: wsl-bash {0} # root shell
         run: |
-          docker build . -t memgraph-mage:prod --target prod
-          docker build . -t memgraph-mage:dev --target dev
+          sudo apt update
+          sudo apt install apt-transport-https ca-certificates curl software-properties-common
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable"
+          apt-cache policy docker-ce
+          sudo apt install docker-ce
+
+          sudo docker build . -t memgraph-mage:prod --target prod
+          sudo docker build . -t memgraph-mage:dev --target dev
 
       - name: Run Memgraph MAGE:prod image
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,8 +112,7 @@ jobs:
           sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu focal stable"
           apt-cache policy docker-ce
           sudo apt -y install docker-ce
-          sudo systemctl status docker
-          sudo systemctl start docker
+          sudo service docker start
 
           sudo docker build . -t memgraph-mage:prod --target prod
           sudo docker build . -t memgraph-mage:dev --target dev


### PR DESCRIPTION
### Description

Please briefly explain the changes you made here.

### Pull request type

- [ ] Bugfix
- [ ] Algorithm/Module
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Unit tests
- [ ] End-to-end tests
- [ ] Code documentation
- [ ] README short description
- [ ] Documentation on [memgraph/docs](https://github.com/memgraph/docs)

######################################

Tried testing build with Docker on windows virtual environment and due to issues with windows server 2019 and windows server 2022 we are closing PR. Followig issues are here:

1. `Windows server 2019` - Currently nope, you can't install Docker Desktop in CI due to limitations of virtual environments:

  - Microsoft-Hyper-V component is not enabled on Windows Server 2019 image and needs reboot to enable this component.
  - DSv2 vm instance, they are currently using, doesn't support nested virtualization

4. `Windows Server 2022` - WSL2 has been removed from Windows Server 2022 so it's not possible to run Linux containers in WSL. See microsoft/WSL#6301 (comment)

See whole discussion here:https://github.com/actions/virtual-environments/issues/1143

