### PR TITLE
Fix ID validity check

### DIFF
--- a/cpp/mg_utility/mg_graph.hpp
+++ b/cpp/mg_utility/mg_graph.hpp
@@ -71,7 +71,7 @@ class Graph : public GraphView<TSize> {
   ///
   /// @return all incident edges
   const std::vector<TSize> &IncidentEdges(TSize node_id) const override {
-    if (node_id < 0 && node_id >= nodes_.size()) {
+    if (node_id < 0 || node_id >= nodes_.size()) {
       throw mg_exception::InvalidIDException();
     }
 
@@ -84,7 +84,7 @@ class Graph : public GraphView<TSize> {
   ///
   /// @return vector of neighbours
   const std::vector<TNeighbour> &Neighbours(TSize node_id) const override {
-    if (node_id < 0 && node_id >= nodes_.size()) {
+    if (node_id < 0 || node_id >= nodes_.size()) {
       throw mg_exception::InvalidIDException();
     }
 
@@ -104,7 +104,7 @@ class Graph : public GraphView<TSize> {
   ///
   /// @return vector of neighbours
   const std::vector<TNeighbour> &InNeighbours(TSize node_id) const {
-    if (node_id < 0 && node_id >= nodes_.size()) {
+    if (node_id < 0 || node_id >= nodes_.size()) {
       throw mg_exception::InvalidIDException();
     }
 
@@ -117,7 +117,7 @@ class Graph : public GraphView<TSize> {
   ///
   /// @return target Node struct
   const TNode &GetNode(TSize node_id) const override {
-    if (node_id < 0 && node_id >= nodes_.size()) {
+    if (node_id < 0 || node_id >= nodes_.size()) {
       throw mg_exception::InvalidIDException();
     }
 
@@ -130,7 +130,7 @@ class Graph : public GraphView<TSize> {
   ///
   /// @return Edge struct
   const TEdge &GetEdge(TSize edge_id) const override {
-    if (edge_id < 0 && edge_id >= edges_.size()) {
+    if (edge_id < 0 || edge_id >= edges_.size()) {
       throw mg_exception::InvalidIDException();
     }
     return edges_[edge_id];
@@ -142,7 +142,7 @@ class Graph : public GraphView<TSize> {
   ///
   /// @return double weight
   const double &GetWeight(TSize edge_id) const {
-    if (edge_id < 0 && edge_id >= edges_.size()) {
+    if (edge_id < 0 || edge_id >= edges_.size()) {
       throw mg_exception::InvalidIDException();
     }
     return weights_[edge_id];
@@ -246,10 +246,10 @@ class Graph : public GraphView<TSize> {
   /// @param[in] node_from node id of node on same edge
   /// @param[in] node_to node id of node on same edge
   void EraseEdge(TSize node_from, TSize node_to) {
-    if (node_from < 0 && node_from >= nodes_.size()) {
+    if (node_from < 0 || node_from >= nodes_.size()) {
       throw mg_exception::InvalidIDException();
     }
-    if (node_to < 0 && node_to >= nodes_.size()) {
+    if (node_to < 0 || node_to >= nodes_.size()) {
       throw mg_exception::InvalidIDException();
     }
 


### PR DESCRIPTION
### Description

Currently, ID validity checks in the C API never throw exceptions. This PR updates the check logic to cover both cases where inner IDs are invalid (under 0 / over N of nodes/edges).

### Pull request type

- [x] Bugfix
- [ ] Algorithm/Module
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Unit tests
- [ ] End-to-end tests
- [ ] Code documentation
- [ ] README short description
- [ ] Documentation on [memgraph/docs](https://github.com/memgraph/docs)

######################################
