### PR TITLE
changed deletion of nodes from recursive dfs

### DIFF
--- a/e2e/max_flow_test/test_path_recursive_return/input.cyp
+++ b/e2e/max_flow_test/test_path_recursive_return/input.cyp
@@ -1,0 +1,12 @@
+MERGE (a:Node {id: 0}) MERGE (b:Node {id: 6}) CREATE (a)-[:RELATION {weight: 1}]->(b);
+MERGE (a:Node {id: 6}) MERGE (b:Node {id: 7}) CREATE (a)-[:RELATION {weight: 1}]->(b);
+MERGE (a:Node {id: 7}) MERGE (b:Node {id: 8}) CREATE (a)-[:RELATION {weight: 1}]->(b);
+MERGE (a:Node {id: 0}) MERGE (b:Node {id: 1}) CREATE (a)-[:RELATION {weight: 6}]->(b);
+MERGE (a:Node {id: 0}) MERGE (b:Node {id: 2}) CREATE (a)-[:RELATION {weight: 14}]->(b);
+MERGE (a:Node {id: 1}) MERGE (b:Node {id: 2}) CREATE (a)-[:RELATION {weight: 1}]->(b);
+MERGE (a:Node {id: 1}) MERGE (b:Node {id: 3}) CREATE (a)-[:RELATION {weight: 5}]->(b);
+MERGE (a:Node {id: 2}) MERGE (b:Node {id: 3}) CREATE (a)-[:RELATION {weight: 7}]->(b);
+MERGE (a:Node {id: 2}) MERGE (b:Node {id: 4}) CREATE (a)-[:RELATION {weight: 10}]->(b);
+MERGE (a:Node {id: 3}) MERGE (b:Node {id: 4}) CREATE (a)-[:RELATION {weight: 1}]->(b);
+MERGE (a:Node {id: 3}) MERGE (b:Node {id: 5}) CREATE (a)-[:RELATION {weight: 11}]->(b);
+MERGE (a:Node {id: 4}) MERGE (b:Node {id: 5}) CREATE (a)-[:RELATION {weight: 12}]->(b);

--- a/e2e/max_flow_test/test_path_recursive_return/test.yml
+++ b/e2e/max_flow_test/test_path_recursive_return/test.yml
@@ -1,0 +1,7 @@
+query: >
+  MATCH (source {id: 0}), (sink {id: 5})
+  CALL max_flow.get_flow(source, sink)
+  YIELD max_flow RETURN max_flow;
+
+output:
+    - max_flow: 20

--- a/python/max_flow.py
+++ b/python/max_flow.py
@@ -181,7 +181,7 @@ def DFS_path_finding(
                 return min(remaining_capacity, flow_bottleneck)
 
     # no path found with this vertex, remove it and its edge
-    path = path[:-2]
+    del path[-2:]
 
     return -1
 

--- a/python/max_flow.py
+++ b/python/max_flow.py
@@ -181,8 +181,7 @@ def DFS_path_finding(
                 return min(remaining_capacity, flow_bottleneck)
 
     # no path found with this vertex, remove it and its edge
-    # del path[-2:]
-    path = path[:-2]
+    del path[-2:]
 
     return -1
 

--- a/python/max_flow.py
+++ b/python/max_flow.py
@@ -181,7 +181,8 @@ def DFS_path_finding(
                 return min(remaining_capacity, flow_bottleneck)
 
     # no path found with this vertex, remove it and its edge
-    del path[-2:]
+    # del path[-2:]
+    path = path[:-2]
 
     return -1
 


### PR DESCRIPTION
### Description

Recursive DFS used for finding flows in the Max Flow algorithm was failing when returning from a recursive call for multiple levels. `path = path[:-2]` simply reassigned the variable inside that function call, and didn't modify the list itself, leaving edges in path that shouldn't be there. `del path[-2:]` modifies the list at the original address, which is the wanted functionality.

### Pull request type

- [x] Bugfix
- [ ] Algorithm/Module
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Related issues

#140 

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Unit tests
- [ ] End-to-end tests
- [ ] Code documentation
- [ ] README short description
- [ ] Documentation on [memgraph/docs](https://github.com/memgraph/docs)

######################################
