### PR TITLE
Make Graph Coloring output vertices and integers instead of strings

### DIFF
--- a/e2e/graph_coloring_test/test_convergence_callback/test.yml
+++ b/e2e/graph_coloring_test/test_convergence_callback/test.yml
@@ -7,8 +7,7 @@ query: >
         convergence_callback_actions: ["SimpleTunneling"]
         })
         YIELD node, color
-    MATCH (a:Cell) WHERE toString(id(a)) = node 
-    RETURN COUNT(a.id) AS id_count, COUNT(color) AS color_count;
+    RETURN COUNT(node.id) AS id_count, COUNT(color) AS color_count;
 
 output:
     - id_count: 5

--- a/e2e/graph_coloring_test/test_graph_init_algorithms/test.yml
+++ b/e2e/graph_coloring_test/test_graph_init_algorithms/test.yml
@@ -2,8 +2,7 @@ query: >
     CALL graph_coloring.color_graph(
         {init_algorithms: ["SDO", "LDO"]})
         YIELD node, color
-    MATCH (a:Cell) WHERE toString(id(a)) = node 
-    RETURN COUNT(a.id) AS id_count, COUNT(color) AS color_count;
+    RETURN COUNT(node.id) AS id_count, COUNT(color) AS color_count;
 
 output:
     - id_count: 5

--- a/e2e/graph_coloring_test/test_graph_one_node/test.yml
+++ b/e2e/graph_coloring_test/test_graph_one_node/test.yml
@@ -2,8 +2,7 @@ query: >
     CALL graph_coloring.color_graph(
         {no_of_colors: 1})
         YIELD node, color
-    MATCH (a:Cell) WHERE toString(id(a)) = node 
-    RETURN a.id AS id, color;
+    RETURN node.id AS id, color;
 output:
     - id: 0
-      color: "0"
+      color: 0

--- a/e2e/graph_coloring_test/test_graph_parallel/test.yml
+++ b/e2e/graph_coloring_test/test_graph_parallel/test.yml
@@ -6,8 +6,7 @@ query: >
         no_of_chunks: 2,
         population_factory: "ChainChunkFactory"})
         YIELD node, color
-    MATCH (a:Cell) WHERE toString(id(a)) = node 
-    RETURN COUNT(a.id) AS id_count, COUNT(color) AS color_count;
+    RETURN COUNT(node.id) AS id_count, COUNT(color) AS color_count;
 
 output:
     - id_count: 5

--- a/e2e/graph_coloring_test/test_graph_without_weight/test.yml
+++ b/e2e/graph_coloring_test/test_graph_without_weight/test.yml
@@ -1,7 +1,6 @@
 query: >
     CALL graph_coloring.color_graph() YIELD node, color
-    MATCH (a:Cell) WHERE toString(id(a)) = node 
-    RETURN COUNT(a.id) AS id_count, COUNT(color) AS color_count;
+    RETURN COUNT(node.id) AS id_count, COUNT(color) AS color_count;
 
 output:
     - id_count: 5

--- a/e2e/graph_coloring_test/test_large_graph/test.yml
+++ b/e2e/graph_coloring_test/test_large_graph/test.yml
@@ -1,7 +1,6 @@
 query: >
     CALL graph_coloring.color_graph() YIELD node, color
-    MATCH (a:BaseStation) WHERE toString(id(a)) = node 
-    RETURN COUNT(a.id) AS id_count, COUNT(color) AS color_count;
+    RETURN COUNT(node.id) AS id_count, COUNT(color) AS color_count;
 
 output:
     - id_count: 200

--- a/e2e/graph_coloring_test/test_multiple_mutation/test.yml
+++ b/e2e/graph_coloring_test/test_multiple_mutation/test.yml
@@ -4,8 +4,7 @@ query: >
         mutation: "MultipleMutation",
         multiple_mutation_no_of_nodes: 3})
         YIELD node, color
-    MATCH (a:Cell) WHERE toString(id(a)) = node 
-    RETURN COUNT(a.id) AS id_count, COUNT(color) AS color_count;
+    RETURN COUNT(node.id) AS id_count, COUNT(color) AS color_count;
 
 output:
     - id_count: 5

--- a/e2e/graph_coloring_test/test_random_mutation/test.yml
+++ b/e2e/graph_coloring_test/test_random_mutation/test.yml
@@ -4,8 +4,7 @@ query: >
         mutation: "RandomMutation",
         random_mutation_probability: 0.5})
         YIELD node, color
-    MATCH (a:Cell) WHERE toString(id(a)) = node 
-    RETURN COUNT(a.id) AS id_count, COUNT(color) AS color_count;
+    RETURN COUNT(node.id) AS id_count, COUNT(color) AS color_count;
 
 output:
     - id_count: 5

--- a/python/graph_coloring.py
+++ b/python/graph_coloring.py
@@ -21,7 +21,6 @@ def color_graph(
     solution = algorithm.run(graph, parameters)
     return [
         mgp.Record(node=context.graph.get_vertex_by_id(node), color=color)
-        # mgp.Record(node=str(graph.label(node)), color=str(color))
         for node, color in enumerate(solution.chromosome)
     ]
 

--- a/python/graph_coloring.py
+++ b/python/graph_coloring.py
@@ -20,7 +20,7 @@ def color_graph(
     algorithm = parameters[Parameter.ALGORITHM]
     solution = algorithm.run(graph, parameters)
     return [
-        mgp.Record(node=context.graph.get_vertex_by_id(node), color=color)
+        mgp.Record(node=context.graph.get_vertex_by_id(graph.label(node)), color=color)
         for node, color in enumerate(solution.chromosome)
     ]
 
@@ -46,7 +46,7 @@ def color_subgraph(
     algorithm = parameters[Parameter.ALGORITHM]
     solution = algorithm.run(graph, parameters)
     return [
-        mgp.Record(node=context.graph.get_vertex_by_id(node), color=color)
+        mgp.Record(node=context.graph.get_vertex_by_id(graph.label(node)), color=color)
         for node, color in enumerate(solution.chromosome)
     ]
 

--- a/python/graph_coloring.py
+++ b/python/graph_coloring.py
@@ -10,7 +10,7 @@ from mage.graph_coloring_module import IncorrectParametersException
 @mgp.read_proc
 def color_graph(
     context: mgp.ProcCtx, parameters: mgp.Map = {}, edge_property: str = "weight"
-) -> mgp.Record(node=str, color=str):
+) -> mgp.Record(node=mgp.Vertex, color=int):
     """
     Example:
     CALL graph_coloring.color_graph() YIELD *;
@@ -20,7 +20,8 @@ def color_graph(
     algorithm = parameters[Parameter.ALGORITHM]
     solution = algorithm.run(graph, parameters)
     return [
-        mgp.Record(node=str(graph.label(node)), color=str(color))
+        mgp.Record(node=context.graph.get_vertex_by_id(node), color=color)
+        # mgp.Record(node=str(graph.label(node)), color=str(color))
         for node, color in enumerate(solution.chromosome)
     ]
 
@@ -32,7 +33,7 @@ def color_subgraph(
     edges: mgp.List[mgp.Edge],
     parameters: mgp.Map = {},
     edge_property: str = "weight",
-) -> mgp.Record(node=str, color=str):
+) -> mgp.Record(node=mgp.Vertex, color=int):
     """
     Example:
     MATCH (a:Cell)-[e:CLOSE_TO]->(b:Cell)
@@ -46,7 +47,7 @@ def color_subgraph(
     algorithm = parameters[Parameter.ALGORITHM]
     solution = algorithm.run(graph, parameters)
     return [
-        mgp.Record(node=str(graph.label(node)), color=str(color))
+        mgp.Record(node=context.graph.get_vertex_by_id(node), color=color)
         for node, color in enumerate(solution.chromosome)
     ]
 


### PR DESCRIPTION
### Description

As was requested, outputs of Graph Coloring algorithm were changed from `vertex_id` and `string` representing color to `mgp.Vertex` and `int`

### Pull request type

- [x] Feature


### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [x] Core algorithm/module implementation
- [x] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [x] Unit tests
- [x] End-to-end tests
- [x] Code documentation
- [x] README short description
- [x] Documentation on [memgraph/docs](https://github.com/memgraph/docs)

######################################
