### PR TITLE
Update test badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
     <a href="https://github.com/memgraph/mage/actions" alt="Actions">
-        <img src="https://img.shields.io/github/workflow/status/memgraph/mage/workflows/test.yml?branch=main&label=build%20and%20test&logo=github"/>
+        <img src="https://img.shields.io/github/actions/workflow/status/memgraph/mage/test.yml?branch=main&label=build%20and%20test&logo=github"/>
     </a>
     <a href="https://github.com/memgraph/mage/blob/main/LICENSE" alt="Licence">
         <img src="https://img.shields.io/github/license/memgraph/mage" />

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
     <a href="https://github.com/memgraph/mage/actions" alt="Actions">
-        <img src="https://img.shields.io/github/workflow/status/memgraph/mage/Build%20and%20Test?label=build%20and%20test&logo=github"/>
+        <img src="https://img.shields.io/github/workflow/status/memgraph/mage/workflows/test.yml?branch=main&logo=github"/>
     </a>
     <a href="https://github.com/memgraph/mage/blob/main/LICENSE" alt="Licence">
         <img src="https://img.shields.io/github/license/memgraph/mage" />

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
     <a href="https://github.com/memgraph/mage/actions" alt="Actions">
-        <img src="https://img.shields.io/github/workflow/status/memgraph/mage/workflows/test.yml?branch=main&logo=github"/>
+        <img src="https://img.shields.io/github/workflow/status/memgraph/mage/workflows/test.yml?branch=main&label=build%20and%20test&logo=github"/>
     </a>
     <a href="https://github.com/memgraph/mage/blob/main/LICENSE" alt="Licence">
         <img src="https://img.shields.io/github/license/memgraph/mage" />


### PR DESCRIPTION
### Description

Our badge is showing an [issue](https://github.com/badges/shields/issues/8671) from Shields.io because they have changed the way of adding a badge for tests that are a part of a GitHub workflow. I changed the URL for the badge.

### Pull request type

- [x] Other (please describe): README update

