### PR TITLE
[main < T333-MAGE] Bump pytorch version up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
     && export PATH="/root/.cargo/bin:${PATH}" \
     && python3 -m  pip install -r /mage/python/requirements.txt \
     && python3 -m  pip install -r /mage/python/tests/requirements.txt \
-    && python3 -m  pip install torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-1.12.0+cu102.html \
+    && python3 -m  pip install torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-1.13.1+cu117.html \
     && python3 /mage/setup build -p /usr/lib/memgraph/query_modules/
 
 #DGL build from source

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -48,7 +48,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
     && export PATH="/root/.cargo/bin:${PATH}" \
     && python3 -m  pip install -r /mage/python/requirements.txt \
     && python3 -m  pip install -r /mage/python/tests/requirements.txt \
-    && python3 -m  pip install torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-1.12.0+cu102.html\
+    && python3 -m  pip install torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-1.13.1+cu117.html\
     && python3 /mage/setup build -p /usr/lib/memgraph/query_modules/
 
 #DGL build from source

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,7 +5,7 @@ networkx==2.6.2
 python-Levenshtein==0.12.1
 elasticsearch==8.4.3
 gensim==4.0.0
-torch==1.12.0
+torch==1.13.1
 six==1.16.0
 torchmetrics==0.9.3
 igraph==0.10.2


### PR DESCRIPTION
### Description

Bump pytorch version up to 1.13.1+cu117 to avoid a critical PyTorch vulnerability ([Dependabot alert](https://github.com/advisories/GHSA-47fc-vmwq-366v)).

### Pull request type

- [x] Build related changes
