### PR TITLE
Add CSV export query results module

### DIFF
--- a/python/export_util.py
+++ b/python/export_util.py
@@ -1,9 +1,14 @@
+import csv
+import io
+import json as js
+import mgp
+
 from dataclasses import dataclass
 from datetime import datetime, date, time, timedelta
-import json as js
+from gqlalchemy import Memgraph
+from typing import Any, Dict, List, Union
+
 from mage.export_import_util.parameters import Parameter
-import mgp
-from typing import Union, List, Dict, Any
 
 
 @dataclass
@@ -124,3 +129,80 @@ def json(ctx: mgp.ProcCtx, path: str) -> mgp.Record():
         raise OSError("Could not open or write to the file.")
 
     return mgp.Record()
+
+
+def save_file(file_path: str, data_list: list):
+    with open(
+        file_path,
+        "w",
+        newline="",
+        encoding="utf8",
+    ) as f:
+        writer2 = csv.writer(f)
+        writer2.writerows(data_list)
+
+
+def stream(data_list: list) -> str:
+    output = io.StringIO()
+    writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC)
+    writer.writerows(data_list)
+    return output.getvalue()
+
+
+@mgp.read_proc
+def csv_query(
+    context: mgp.ProcCtx,
+    query: str,
+    file: str = "",
+    config: mgp.Map = {},
+) -> mgp.Record(file_path=str, data=str):
+    """
+    Procedure to export query results to a CSV file.
+    Args:
+        context (mgp.ProcCtx): Reference to the context execution.
+        query (str): A query from which the results will be saved to a CSV file.
+        file (str, optional): Name of the CSV file where the query results will be exported. Defaults to an empty string.
+        confing (mgp.Map, optional): Additional configuration. Currently only 'stream' key can be set to either True or False values. Defaults to an empty dictionary.
+    Returns:
+        mgp.Record(
+            file_path (str): If the file name was provided, this is the path to the saved CSV file. Otherwise, it is an empty string.
+            data (str): A stream of query results in a CSV format.
+        )
+    Raises:
+        Exception: If neither file nor config are provided, or if only config is provided with stream set to False. Also if query yields no results or if the database is empty.
+
+    Examples:
+    """
+
+    # file or config have to be provided
+    if not file and not config:
+        raise Exception("Please provide file name and/or config.")
+
+    # only config provided with stream set to false
+    if not file and config and not config.get("stream"):
+        raise Exception(
+            "If you provided only stream config, it has to be true to get any results."
+        )
+
+    memgraph = Memgraph()
+    results = list(memgraph.execute_and_fetch(query))
+
+    # if query yields no result
+    if not len(results):
+        raise Exception(
+            "Your query yields no results. Check if the database is empty or rewrite the provided query."
+        )
+
+    result_keys = list(results[0])
+    data_list = [result_keys] + [list(result.values()) for result in results]
+    data = ""
+    file_path = ""
+
+    if file:
+        file_path = "/var/lib/memgraph/internal_modules/" + file
+        save_file(file_path, data_list)
+
+    if config and config.get("stream"):
+        data = stream(data_list)
+
+    return mgp.Record(file_path=file_path, data=data)


### PR DESCRIPTION
### Description

I created `csv_query` procedure inside `export_util` module. Find arguments description in docstring. 

TODO / discuss with @Josipmrden:

- [ ] Potentially use `pandas` instead of `csv` - what are the pros?
- [ ] Leave config as a map or add stream as an argument. Another option is to return the stream and remove it from the arguments altogether. I vote for this. 
- [ ] Add tests
- [ ] Add examples in the docstring
- [ ] Write docs 
- [ ] Probably edit the path inside the code to be `/usr/lib/memgraph/query_modules` instead of `/var/lib/memgraph/internal_modules` used for development. In `json()` procedure in this module, I left it to the user to provide the whole path and advised them to provide `/usr/lib/memgraph/query_modules/something.json`. This may be a better way to go.

### Pull request type

- [x] Algorithm/Module

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Unit tests
- [ ] End-to-end tests
- [ ] Code documentation
- [ ] README short description
- [ ] Documentation on [memgraph/docs](https://github.com/memgraph/docs)

######################################
