### PR TITLE
Switch to safe torch version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
     && export PATH="/root/.cargo/bin:${PATH}" \
     && python3 -m  pip install -r /mage/python/requirements.txt \
     && python3 -m  pip install -r /mage/python/tests/requirements.txt \
-    && python3 -m  pip install torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-1.12.0+cu102.html\
+    && python3 -m  pip install torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-1.13.1+cu117.html\
     && python3 /mage/setup build -p /usr/lib/memgraph/query_modules/
 
 #DGL build from source

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -48,7 +48,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
     && export PATH="/root/.cargo/bin:${PATH}" \
     && python3 -m  pip install -r /mage/python/requirements.txt \
     && python3 -m  pip install -r /mage/python/tests/requirements.txt \
-    && python3 -m  pip install torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-1.12.0+cu102.html \
+    && python3 -m  pip install torch-sparse torch-cluster torch-spline-conv torch-geometric torch-scatter -f https://data.pyg.org/whl/torch-1.13.1+cu117.html \
     && python3 /mage/setup build -p /usr/lib/memgraph/query_modules/
 
 #DGL build from source

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,7 +5,7 @@ networkx==2.6.2
 python-Levenshtein==0.12.1
 elasticsearch==8.4.3
 gensim==4.0.0
-torch==1.12.0
+torch==1.13.1
 six==1.16.0
 torchmetrics==0.9.3
 igraph==0.10.2


### PR DESCRIPTION
### Description

This PR upgrades the torch requirement to version 1.13.1 in order to avoid a pytorch [vulnerability](https://github.com/memgraph/mage/security/dependabot/1). These changes have already been merged (#197), but got overwritten by #199.

### Pull request type

- [x] Bugfix

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Unit tests
- [ ] End-to-end tests
- [ ] Code documentation
- [ ] README short description
- [ ] Documentation on [memgraph/docs](https://github.com/memgraph/docs)

######################################
