### PR TITLE
[E-path < T667-T668] Path subgraph improvement and path refactor

### DIFF
--- a/cpp/path_module/algorithm/path.cpp
+++ b/cpp/path_module/algorithm/path.cpp
@@ -61,7 +61,7 @@ Path::PathHelper::PathHelper(const mgp::Map &config) {
   config_.bfs = value.IsNull() ? false : value.ValueBool();
 }
 
-Path::RelDirection Path::PathHelper::GetDirection(std::string &rel_type) const {
+Path::RelDirection Path::PathHelper::GetDirection(const std::string &rel_type) const {
   auto it = config_.relationship_sets.find(rel_type);
   if (it == config_.relationship_sets.end()) {
     return RelDirection::kNone;

--- a/cpp/path_module/algorithm/path.cpp
+++ b/cpp/path_module/algorithm/path.cpp
@@ -1,10 +1,5 @@
 #include "path.hpp"
 
-#include <algorithm>
-#include <cstdint>
-#include <queue>
-#include <unordered_set>
-
 #include "mgp.hpp"
 
 Path::PathHelper::PathHelper(const mgp::List &labels, const mgp::List &relationships, int64_t min_hops,

--- a/cpp/path_module/algorithm/path.hpp
+++ b/cpp/path_module/algorithm/path.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <limits>
 #include <mgp.hpp>
 
 #include <queue>

--- a/cpp/path_module/algorithm/path.hpp
+++ b/cpp/path_module/algorithm/path.hpp
@@ -66,14 +66,21 @@ struct Config {
   int64_t max_hops = -1;
   bool any_incoming = false;
   bool any_outgoing = false;
+  bool filter_start_node = false;
+  bool begin_sequence_at_start = false;
+  bool bfs = false;
 };
 
 class PathHelper {
  public:
-  PathHelper(const mgp::List &labels, const mgp::List &relationships, int64_t min_hops, int64_t max_hops);
+  explicit PathHelper(const mgp::List &labels, const mgp::List &relationships, int64_t min_hops, int64_t max_hops);
+  explicit PathHelper(const mgp::Map &config);
   RelDirection GetDirection(std::string &rel_type);
 
   bool AnyDirected(bool outgoing) const { return outgoing ? config_.any_outgoing : config_.any_incoming; }
+  bool FilterNodes(bool is_start) const { return (config_.filter_start_node || !is_start); }
+  bool FilterRelationships(bool is_start) const { return (config_.begin_sequence_at_start || !is_start); }
+  LabelBools GetLabelBools(const mgp::Node &node);
   bool PathSizeOk(int64_t path_size) const;
   bool PathTooBig(int64_t path_size) const;
   bool Whitelisted(bool whitelisted) const;
@@ -98,10 +105,10 @@ void PathDFS(mgp::Path &path, const mgp::RecordFactory &record_factory, int64_t 
 
 void StartFunction(const mgp::Node &node, const mgp::RecordFactory &record_factory, PathHelper &path_helper);
 
+void RunBFS(std::unordered_set<mgp::Node> &start_nodes, mgp::List &to_be_returned_nodes, Path::PathHelper &path_helper);
 void SubgraphNodes(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
 void SubgraphAll(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
-void VisitNode(const mgp::Node node, std::map<mgp::Node, std::int64_t> &visited_nodes, bool is_start,
-               const mgp::Map &config, int64_t hop_count, Path::LabelSets &labelFilterSets,
-               mgp::List &to_be_returned_nodes);
+void VisitNode(const mgp::Node &node, std::map<mgp::Node, std::int64_t> &visited_nodes, bool is_start,
+              int64_t hop_count, mgp::List &to_be_returned_nodes, PathHelper &path_helper);
 
 }  // namespace Path

--- a/cpp/path_module/algorithm/path.hpp
+++ b/cpp/path_module/algorithm/path.hpp
@@ -80,7 +80,7 @@ class PathHelper {
   explicit PathHelper(const mgp::List &labels, const mgp::List &relationships, int64_t min_hops, int64_t max_hops);
   explicit PathHelper(const mgp::Map &config);
 
-  RelDirection GetDirection(std::string &rel_type) const;
+  RelDirection GetDirection(const std::string &rel_type) const;
   LabelBools GetLabelBools(const mgp::Node &node) const;
 
   bool AnyDirected(bool outgoing) const { return outgoing ? config_.any_outgoing : config_.any_incoming; }

--- a/cpp/path_module/algorithm/path.hpp
+++ b/cpp/path_module/algorithm/path.hpp
@@ -73,10 +73,11 @@ class PathHelper {
 
   bool AnyDirected(bool outgoing) const { return outgoing ? config_.any_outgoing : config_.any_incoming; }
   bool PathSizeOk(int64_t path_size) const;
+  bool PathTooBig(int64_t path_size) const;
   bool Whitelisted(bool whitelisted) const;
   bool ShouldExpand(const LabelBools &label_bools) const;
   void FilterLabelBoolStatus();
-  void FilterLabel(std::string_view label, LabelBools &labelBools);
+  void FilterLabel(std::string_view label, LabelBools &label_bools);
   void ParseLabels(const mgp::List &list_of_labels);
   void ParseRelationships(const mgp::List &list_of_relationships);
 

--- a/cpp/path_module/algorithm/path.hpp
+++ b/cpp/path_module/algorithm/path.hpp
@@ -62,8 +62,10 @@ struct Config {
   LabelBoolsStatus label_bools_status;
   std::unordered_map<std::string, RelDirection> relationship_sets;
   LabelSets label_sets;
-  int64_t min_hops, max_hops;
-  bool any_incoming, any_outgoing;
+  int64_t min_hops = -1;
+  int64_t max_hops = -1;
+  bool any_incoming = false;
+  bool any_outgoing = false;
 };
 
 class PathHelper {

--- a/cpp/path_module/algorithm/path.hpp
+++ b/cpp/path_module/algorithm/path.hpp
@@ -152,10 +152,8 @@ void Create(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_m
 
 void Expand(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
 
-void RunBFS(std::unordered_set<mgp::Node> &start_nodes, mgp::List &to_be_returned_nodes, Path::PathHelper &path_helper);
 void SubgraphNodes(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
+
 void SubgraphAll(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory);
-void VisitNode(const mgp::Node &node, std::map<mgp::Node, std::int64_t> &visited_nodes, bool is_start,
-               int64_t hop_count, mgp::List &to_be_returned_nodes, PathHelper &path_helper);
 
 }  // namespace Path

--- a/cpp/path_module/path_module.cpp
+++ b/cpp/path_module/path_module.cpp
@@ -4,7 +4,7 @@
 
 extern "C" int mgp_init_module(struct mgp_module *module, struct mgp_memory *memory) {
   try {
-    mgp::memory = memory;
+    mgp::MemoryDispatcherGuard guard{memory};
     AddProcedure(
         Path::Expand, std::string(Path::kProcedureExpand).c_str(), mgp::ProcedureType::Read,
         {mgp::Parameter(std::string(Path::kArgumentStartExpand).c_str(), mgp::Type::Any),

--- a/e2e/path_test/test_expand1/test.yml
+++ b/e2e/path_test/test_expand1/test.yml
@@ -1,7 +1,17 @@
 query: >
-    MATCH (d:Dog)
-    CALL path.expand(d,["HUNTS>"],[],0,3) YIELD result RETURN result;
-
-
+  MATCH (d:Dog) CALL path.expand(d,["HUNTS>"],[],0,3) YIELD result RETURN
+  result;
 output:
-    - result: {'nodes': [{'labels': ['Dog'],'properties': {'name': 'Rex'}},{'labels': ['Cat'],'properties': {'name': 'Tom'}}],'relationships': [{'label': 'HUNTS','properties': {}}]}
+  - result:
+      nodes:
+        - labels:
+            - Dog
+          properties:
+            name: Rex
+        - labels:
+            - Cat
+          properties:
+            name: Tom
+      relationships:
+        - label: HUNTS
+          properties: {}

--- a/e2e/path_test/test_expand1/test.yml
+++ b/e2e/path_test/test_expand1/test.yml
@@ -1,5 +1,5 @@
 query: >
-  MATCH (d:Dog) CALL path.expand(d,["HUNTS>"],[],0,3) YIELD result RETURN
+  MATCH (d:Dog) CALL path.expand(d,["HUNTS>"],[],1,3) YIELD result RETURN
   result;
 output:
   - result:

--- a/e2e/path_test/test_expand2/test.yml
+++ b/e2e/path_test/test_expand2/test.yml
@@ -1,9 +1,54 @@
 query: >
-    MATCH (d:Dog)
-    CALL path.expand(d,[],["-Human","/Cat"],0,3) YIELD result RETURN result;
-
-
+  MATCH (d:Dog) CALL path.expand(d,[],["-Human","/Cat"],0,3) YIELD result RETURN
+  result;
 output:
-    - result: {'nodes': [{'labels': ['Dog'],'properties': {'name': 'Rex'}},{'labels': ['Cat'],'properties': {'name': 'Tom'}}],'relationships': [{'label': 'HUNTS','properties': {}}]}
-    - result: {'nodes': [{'labels': ['Dog'],'properties': {'name': 'Rex'}},{'labels': ['Cat'],'properties': {'name': 'Rinko'}}],'relationships': [{'label': 'BEST_FRIENDS','properties': {}}]}
-    - result: {'nodes': [{'labels': ['Dog'], 'properties': {'name': 'Rex'}}, {'labels': ['Zadar'], 'properties': {}},  {'labels': ['Mouse'], 'properties': {'name': 'Squiggles'}}, {'labels': ['Cat'],'properties': {'name': 'Tom'}}],'relationships': [{'label': 'LIVES', 'properties': {}}, {'label': 'RUNS_THROUGH','properties': {}},{'label': 'CATCHES','properties': {}}]}
+  - result:
+      nodes:
+        - labels:
+            - Dog
+          properties:
+            name: Rex
+        - labels:
+            - Cat
+          properties:
+            name: Tom
+      relationships:
+        - label: HUNTS
+          properties: {}
+  - result:
+      nodes:
+        - labels:
+            - Dog
+          properties:
+            name: Rex
+        - labels:
+            - Cat
+          properties:
+            name: Rinko
+      relationships:
+        - label: BEST_FRIENDS
+          properties: {}
+  - result:
+      nodes:
+        - labels:
+            - Dog
+          properties:
+            name: Rex
+        - labels:
+            - Zadar
+          properties: {}
+        - labels:
+            - Mouse
+          properties:
+            name: Squiggles
+        - labels:
+            - Cat
+          properties:
+            name: Tom
+      relationships:
+        - label: LIVES
+          properties: {}
+        - label: RUNS_THROUGH
+          properties: {}
+        - label: CATCHES
+          properties: {}

--- a/e2e/path_test/test_expand3/test.yml
+++ b/e2e/path_test/test_expand3/test.yml
@@ -1,7 +1,28 @@
 query: >
-    MATCH (d:Dog)
-    CALL path.expand(d,[">","<OWNS"],[">Zadar","/Human"],3,3) YIELD result RETURN result;
-
-
+  MATCH (d:Dog) CALL path.expand(d,[">","<OWNS"],[">Zadar","/Human"],3,3) YIELD
+  result RETURN result;
 output:
-    - result: {'nodes': [{'labels': ['Dog'],'properties': {'name': 'Rex'}},{'labels': ['Cat'],'properties': {'name': 'Tom'}},{'labels': ['Mouse'],'properties': {'name': 'Squiggles'}},{'labels': ['Zadar'],'properties': {}}],'relationships': [{'label': 'HUNTS','properties': {}},{'label': 'CATCHES','properties': {}},{'label': 'RUNS_THROUGH', 'properties': {}}]}
+  - result:
+      nodes:
+        - labels:
+            - Dog
+          properties:
+            name: Rex
+        - labels:
+            - Cat
+          properties:
+            name: Tom
+        - labels:
+            - Mouse
+          properties:
+            name: Squiggles
+        - labels:
+            - Zadar
+          properties: {}
+      relationships:
+        - label: HUNTS
+          properties: {}
+        - label: CATCHES
+          properties: {}
+        - label: RUNS_THROUGH
+          properties: {}

--- a/e2e/path_test/test_expand4/test.yml
+++ b/e2e/path_test/test_expand4/test.yml
@@ -1,7 +1,5 @@
 query: >
-  MATCH (d:Dog), (h:Human)
-  CALL path.expand([d,id(h)],[],[],1,10) YIELD result RETURN count(result) AS count;
-
-
+  MATCH (d:Dog), (h:Human) CALL path.expand([d,id(h)],[],[],1,10) YIELD result
+  RETURN count(result) AS count;
 output:
-    - count: 142
+  - count: 142

--- a/e2e/path_test/test_subgraph_all_1/test.yml
+++ b/e2e/path_test/test_subgraph_all_1/test.yml
@@ -10,6 +10,10 @@ query: >
 output:
   - nodes:
         - labels:
+            - Operations
+          properties:
+            name: Jill
+        - labels:
             - Research
           properties:
             name: Matt
@@ -17,10 +21,6 @@ output:
             - Operations
           properties:
             name: Steve
-        - labels:
-            - Operations
-          properties:
-            name: Jill
     rels:
         - label: FOLLOWS
           properties: {}

--- a/e2e/path_test/test_subgraph_all_2/test.yml
+++ b/e2e/path_test/test_subgraph_all_2/test.yml
@@ -2,8 +2,8 @@ query: >
   MATCH (p:Strategy {name: "Amber"})
   CALL path.subgraph_all(p, {
       relationshipFilter: [">"],
-      minLevel: 0,
-      maxLevel: 2
+      minHops: 0,
+      maxHops: 2
   })
   YIELD nodes, rels
   RETURN nodes, rels;
@@ -23,6 +23,10 @@ output:
           properties:
             name: Jill
         - labels:
+            - Support
+          properties:
+            name: Jackson
+        - labels:
             - Research
           properties:
             name: Matt
@@ -34,10 +38,6 @@ output:
             - Analytics
           properties:
             name: Zack
-        - labels:
-            - Support
-          properties:
-            name: Jackson
         - labels:
             - Support
           properties:
@@ -57,9 +57,9 @@ output:
           properties: {}
         - label: KNOWS
           properties: {}
-        - label: FOLLOWS
-          properties: {}
         - label: KNOWS
+          properties: {}
+        - label: FOLLOWS
           properties: {}
         - label: KNOWS
           properties: {}

--- a/e2e/path_test/test_subgraph_all_3/test.yml
+++ b/e2e/path_test/test_subgraph_all_3/test.yml
@@ -17,15 +17,15 @@ output:
         - labels:
             - Node
           properties:
+            name: C
+        - labels:
+            - Node
+          properties:
             name: E
         - labels:
             - Node
           properties:
             name: D
-        - labels:
-            - Node
-          properties:
-            name: C
     rels:
         - label: CONNECTED_TO
           properties: {}

--- a/e2e/path_test/test_subgraph_nodes_1/test.yml
+++ b/e2e/path_test/test_subgraph_nodes_1/test.yml
@@ -5,7 +5,7 @@ query: >
       labelFilter: ["+Strategy", "/Operations", ">Research", "-Support", "Analytics"]
   })
   YIELD nodes
-  RETURN nodes;
+  RETURN nodes ORDER BY id(nodes) ASC
 
 output:
       - nodes:
@@ -17,9 +17,9 @@ output:
           labels:
             - Operations
           properties:
-            name: Steve
+            name: Jill
       - nodes:
           labels:
             - Operations
           properties:
-            name: Jill
+            name: Steve

--- a/e2e/path_test/test_subgraph_nodes_2/test.yml
+++ b/e2e/path_test/test_subgraph_nodes_2/test.yml
@@ -2,28 +2,13 @@ query: >
   MATCH (p:Strategy {name: "Amber"})
   CALL path.subgraph_nodes(p, {
       relationshipFilter: [">"],
-      minLevel: 0,
-      maxLevel: 2
+      minHops: 0,
+      maxHops: 2
   })
   YIELD nodes
-  RETURN nodes;
+  RETURN nodes ORDER BY id(nodes);
 
 output:
-      - nodes:
-          labels:
-            - Strategy
-          properties:
-            name: Amber
-      - nodes:
-          labels:
-            - Strategy
-          properties:
-            name: Jacob
-      - nodes:
-          labels:
-            - Operations
-          properties:
-            name: Jill
       - nodes:
           labels:
             - Research
@@ -39,6 +24,21 @@ output:
             - Analytics
           properties:
             name: Zack
+      - nodes:
+          labels:
+            - Operations
+          properties:
+            name: Jill
+      - nodes:
+          labels:
+            - Strategy
+          properties:
+            name: Amber
+      - nodes:
+          labels:
+            - Strategy
+          properties:
+            name: Jacob
       - nodes:
           labels:
             - Support

--- a/e2e/path_test/test_subgraph_nodes_3/test.yml
+++ b/e2e/path_test/test_subgraph_nodes_3/test.yml
@@ -2,7 +2,7 @@ query: >
   MATCH (a:Node {name: "A"})
   CALL path.subgraph_nodes(a, {relationshipFilter: ['CONNECTED_TO>']})
   YIELD nodes
-  RETURN nodes
+  RETURN nodes ORDER BY id(nodes) ASC;
 
 output:
       - nodes:
@@ -19,7 +19,7 @@ output:
           labels:
             - Node
           properties:
-            name: E
+            name: C
       - nodes:
           labels:
             - Node
@@ -29,4 +29,4 @@ output:
           labels:
             - Node
           properties:
-            name: C
+            name: E


### PR DESCRIPTION
### Description

Refactor the path module and change path subgraph to bfs instead of dfs which should improve the speed and lower memory usage by a lot

### Pull request type

- [ ] Bugfix
- [x] Algorithm/Module
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [x] Core algorithm/module implementation
- [x] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [x] Unit tests
- [x] End-to-end tests
- [ ] Code documentation
- [ ] README short description
- [ ] Documentation on [memgraph/docs](https://github.com/memgraph/docs)
- [ ] Update GQLALchemy signatures in [query builder](https://github.com/memgraph/gqlalchemy/blob/main/gqlalchemy/graph_algorithms/query_builder.py  ) using [query module signature generator](https://github.com/memgraph/gqlalchemy/blob/main/scripts/query_module_signature_generator.py)

######################################
