### PR TITLE
Add periodic iterate fix on authentication

### DIFF
--- a/cpp/periodic_module/periodic_iterate.cpp
+++ b/cpp/periodic_module/periodic_iterate.cpp
@@ -156,6 +156,38 @@ std::string ConstructFinalQuery(const std::string &running_query, const std::str
   return fmt::format("{} {}", prefix_query, running_query);
 }
 
+mg::Client::Params GetClientParams() {
+  auto *host = kDefaultHost;
+  auto port = kDefaultPort;
+  auto *username = "";
+  auto *password = "";
+
+  auto *maybe_host = std::getenv(kMgHost);
+  if (maybe_host) {
+    host = std::move(maybe_host);
+  }
+
+  const auto *maybe_port = std::getenv(kMgPort);
+  if (maybe_port) {
+    port = static_cast<uint16_t>(std::move(*maybe_port));
+  }
+
+  const auto *maybe_username = std::getenv(kMgUsername);
+  if (maybe_username) {
+    username = std::move(maybe_username);
+  }
+
+  const auto *maybe_password = std::getenv(kMgPassword);
+  if (maybe_password) {
+    password = std::move(maybe_password);
+  }
+
+  return mg::Client::Params{.host = std::move(host),
+                            .port = std::move(port),
+                            .username = std::move(username),
+                            .password = std::move(password)};
+}
+
 void ExecuteRunningQuery(const std::string running_query, const std::vector<std::string> &columns,
                          const std::vector<std::vector<mg::Value>> &batch) {
   if (!batch.size()) {
@@ -191,38 +223,6 @@ void ValidateBatchSize(const mgp::Value &batch_size_value) {
   if (batch_size <= 0) {
     throw std::runtime_error("Batch size must be a non-negative number!");
   }
-}
-
-mg::Client::Params GetClientParams() {
-  auto *host = kDefaultHost;
-  auto port = kDefaultPort;
-  auto *username = "";
-  auto *password = "";
-
-  auto *maybe_host = std::getenv(kMgHost);
-  if (maybe_host) {
-    host = std::move(maybe_host);
-  }
-
-  const auto *maybe_port = std::getenv(kMgPort);
-  if (maybe_port) {
-    port = static_cast<uint16_t>(std::move(*maybe_port));
-  }
-
-  const auto *maybe_username = std::getenv(kMgUsername);
-  if (maybe_username) {
-    username = std::move(maybe_username);
-  }
-
-  const auto *maybe_password = std::getenv(kMgPassword);
-  if (maybe_password) {
-    password = std::move(maybe_password);
-  }
-
-  return mg::Client::Params{.host = std::move(host),
-                            .port = std::move(port),
-                            .username = std::move(username),
-                            .password = std::move(password)};
 }
 
 void PeriodicIterate(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory) {

--- a/cpp/periodic_module/periodic_iterate.cpp
+++ b/cpp/periodic_module/periodic_iterate.cpp
@@ -123,7 +123,8 @@ std::string ConstructQueryPrefix(const ParamNames &names) {
   return fmt::format("{} {} {}", unwind_batch, with_variables, match_string);
 }
 
-mg::Map ConstructQueryParams(const std::vector<std::string> &columns, const std::vector<std::vector<mg::Value>> &batch) {
+mg::Map ConstructQueryParams(const std::vector<std::string> &columns,
+                             const std::vector<std::vector<mg::Value>> &batch) {
   mg::Map params(1);
   mg::List list_value(batch.size());
 
@@ -167,8 +168,7 @@ void ExecuteRunningQuery(const std::string running_query, const std::vector<std:
 
   auto query_params = ConstructQueryParams(columns, batch);
 
-  mg::Client::Params session_params{.host = "localhost", .port = 7687};
-  auto client = mg::Client::Connect(session_params);
+  auto client = mg::Client::Connect(GetClientParams());
   if (!client) {
     throw std::runtime_error("Unable to connect to client!");
   }
@@ -226,7 +226,8 @@ mg::Client::Params GetClientParams() {
 }
 
 void PeriodicIterate(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, mgp_memory *memory) {
-  mgp::MemoryDispatcherGuard guard{memory};;
+  mgp::MemoryDispatcherGuard guard{memory};
+  ;
   const auto arguments = mgp::List(args);
 
   auto num_of_executed_batches = 0;
@@ -296,7 +297,8 @@ void PeriodicIterate(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *resu
 
 extern "C" int mgp_init_module(struct mgp_module *module, struct mgp_memory *memory) {
   try {
-    mgp::MemoryDispatcherGuard guard{memory};;
+    mgp::MemoryDispatcherGuard guard{memory};
+    ;
     mgp::AddProcedure(
         PeriodicIterate, kProcedurePeriodic, mgp::ProcedureType::Read,
         {mgp::Parameter(kArgumentInputQuery, mgp::Type::String),


### PR DESCRIPTION
### Description

Periodic iterate has not been able to execute queries in an authenticated environment because on one of the paths the client has been connecting to Memgraph without username and password provided. That path has now been covered to provide credentials based on environment variables.

### Pull request type

- [X] Bugfix

### Related issues

Delete if this PR doesn't resolve any issues. Link the issue if it does.

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Unit tests
- [ ] End-to-end tests
- [ ] Code documentation
- [ ] README short description
- [ ] Documentation on [memgraph/docs](https://github.com/memgraph/docs)
- [ ] Update GQLALchemy signatures in [query builder](https://github.com/memgraph/gqlalchemy/blob/main/gqlalchemy/graph_algorithms/query_builder.py  ) using [query module signature generator](https://github.com/memgraph/gqlalchemy/blob/main/scripts/query_module_signature_generator.py)

######################################
