### PR TITLE
Modify CreateCsvFile behavior to not include newline

### DIFF
--- a/cpp/csv_utils_module/algorithm/csv_utils.cpp
+++ b/cpp/csv_utils_module/algorithm/csv_utils.cpp
@@ -14,7 +14,7 @@ void CreateCsvFile(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result
 
     std::ofstream fout;
     fout.open(std::string(filepath), is_append ? std::ofstream::app : std::ofstream::out);
-    fout << content << std::endl;
+    fout << content;
     fout.close();
 
     auto record = record_factory.NewRecord();

--- a/cpp/csv_utils_module/algorithm/csv_utils.cpp
+++ b/cpp/csv_utils_module/algorithm/csv_utils.cpp
@@ -14,7 +14,7 @@ void CreateCsvFile(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result
 
     std::ofstream fout;
     fout.open(std::string(filepath), is_append ? std::ofstream::app : std::ofstream::out);
-    fout << content;
+    fout << content << std::flush;
     fout.close();
 
     auto record = record_factory.NewRecord();


### PR DESCRIPTION
### Description

Modifies the behavior of the `CreateCsvFile` procedure to not include a newline at the end of the line.
This behaviour is required by the Lab.

### Pull request type

- [x] Bugfix
- [ ] Algorithm/Module
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Related issues

Delete if this PR doesn't resolve any issues. Link the issue if it does.

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Unit tests
- [ ] End-to-end tests
- [ ] Code documentation
- [ ] README short description
- [ ] Documentation on [memgraph/docs](https://github.com/memgraph/docs)
- [ ] Update GQLALchemy signatures in [query builder](https://github.com/memgraph/gqlalchemy/blob/main/gqlalchemy/graph_algorithms/query_builder.py  ) using [query module signature generator](https://github.com/memgraph/gqlalchemy/blob/main/scripts/query_module_signature_generator.py)

######################################
