### PR TITLE
Bugfix: Inverting bool value in rust

### DIFF
--- a/rust/rsmgp-sys/src/value/mod.rs
+++ b/rust/rsmgp-sys/src/value/mod.rs
@@ -506,7 +506,7 @@ pub(crate) unsafe fn mgp_raw_value_to_value(
     match invoke_mgp_func!(mgp_value_type, ffi::mgp_value_get_type, value).unwrap() {
         mgp_value_type::MGP_VALUE_TYPE_NULL => Ok(Value::Null),
         mgp_value_type::MGP_VALUE_TYPE_BOOL => Ok(Value::Bool(
-            invoke_mgp_func!(::std::os::raw::c_int, ffi::mgp_value_get_bool, value).unwrap() == 0,
+            invoke_mgp_func!(::std::os::raw::c_int, ffi::mgp_value_get_bool, value).unwrap() != 0,
         )),
         mgp_value_type::MGP_VALUE_TYPE_INT => Ok(Value::Int(
             invoke_mgp_func!(i64, ffi::mgp_value_get_int, value).unwrap(),


### PR DESCRIPTION
### Description

When executing rust procedures, any boolean arguments get negated.

### Pull request type

- [ ] Bugfix

### Related issues

https://github.com/memgraph/mage/issues/426

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Unit tests
- [ ] End-to-end tests
- [ ] Code documentation
- [ ] README short description
- [ ] Documentation on [memgraph/docs](https://github.com/memgraph/docs)
- [ ] Update GQLALchemy signatures in [query builder](https://github.com/memgraph/gqlalchemy/blob/main/gqlalchemy/graph_algorithms/query_builder.py  ) using [query module signature generator](https://github.com/memgraph/gqlalchemy/blob/main/scripts/query_module_signature_generator.py)

######################################
