### PR TITLE
Add dummy package_mage workflow

### DIFF
--- a/.github/workflows/package_mage.yaml
+++ b/.github/workflows/package_mage.yaml
@@ -1,0 +1,51 @@
+name: Package mage
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag_format:
+        type: choice
+        description: "Select the format of the final image tag."
+        default: '<mage-version>-memgraph-<memgraph-version>'
+        options:
+          - '<mage-version>-memgraph-<memgraph-version>'
+          - 'custom'
+      custom_image_tag:
+        type: string
+        description: "Custom tag for the final image. Required if 'image_tag_format' is set to 'custom'."
+        default: ""
+      mage_version:
+        type: string
+        description: "Mage version to build into the package (format: X.Y.Z). Required if 'image_tag_format' is set to '<mage-version>-memgraph-<memgraph-version>'."
+      memgraph_version:
+        type: string
+        description: "Memgraph version to build into the package (format: X.Y.Z). Required if 'image_tag_format' is set to '<mage-version>-memgraph-<memgraph-version>'."
+      download_official_memgraph:
+        description: "Download official Memgraph package?"
+        default: false
+        type: boolean
+      memgraph_download_link:
+        description: "URL of the Memgraph package to download. Required if 'download_official_memgraph' is set to 'false'."
+        default: ""
+        type: string
+      additional_tag:
+        type: choice
+        default: 'none'
+        descritpion: "Additional tag for the image"
+        required: true
+        options:
+          - 'none'
+          - 'latest'
+          - 'fix'
+      force_release:
+        type: boolean
+        description: "Overwrite existing image on dockerhub"
+        default: true
+
+
+jobs:
+  dummy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dummy step
+      run: echo "This is a dummy step"


### PR DESCRIPTION
### Description

This PR creates a dummy package mage workflow.
This will be merged into master ASAP as a dummy workflow.
This is because manual execution isn't possible if a workflow doesn't exits on the default branch (`origin/main` in our case)


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone