### PR TITLE
Fix error propagation in setup script

### DIFF
--- a/setup
+++ b/setup
@@ -4,6 +4,7 @@ import os
 import re
 import subprocess
 import shutil
+import sys
 import glob
 import fnmatch
 import multiprocessing as mp
@@ -414,11 +415,15 @@ def main():
         return
 
     if args.action == "build":
-        run_build_action(vars(args))
+        status = run_build_action(vars(args))
+        if not status:
+            sys.exit(1)
         return
 
     if args.action == "modules_storage":
-        run_modules_storage_setup_action(args.path, args.conf_path)
+        status = run_modules_storage_setup_action(args.path, args.conf_path)
+        if not status:
+            sys.exit(1)
         return
 
 


### PR DESCRIPTION
### Description

This PR fixes error propagation in the setup script. The bug was that when an error happens, example: `Building C++ modules failed`, the script would not return exit code 1. Rather it would just log the error and return exit code 0 as if everything is ok.

### Pull request type

- [x] Bugfix
- [ ] Algorithm/Module
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Related issues

Delete if this PR doesn't resolve any issues. Link the issue if it does.

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Tests provided (unit / e2e)
- [ ] Code documentation
- [ ] README short description


### Documentation checklist
- [ ] Add the documentation label tag
- [ ] Add the bug / feature label tag
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments