### PR TITLE
fix rust module build directory loop

### DIFF
--- a/setup
+++ b/setup
@@ -287,7 +287,8 @@ def build_and_copy_rust_modules(args: Dict[str, Any]) -> bool:
 
     os.chdir(RS_DIRECTORY)
     for project in filter(
-        lambda f: os.path.isdir(f) and f != "rsmgp-sys", os.listdir(RS_DIRECTORY)
+        lambda f: os.path.isdir(os.path.join(RS_DIRECTORY, f)) and f != "rsmgp-sys",
+        os.listdir(RS_DIRECTORY),
     ):
         project_dir = os.path.join(RS_DIRECTORY, project)
         os.chdir(project_dir)


### PR DESCRIPTION
### Description

Fixed the `build_and_copy_rust_modules` directory loop to properly handle the list of projects.

### Pull request type

- [x] Bugfix
- [ ] Algorithm/Module
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Related issues

[Issue 477](https://github.com/memgraph/mage/issues/477)

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Tests provided (unit / e2e)
- [ ] Code documentation
- [ ] README short description


### Documentation checklist
- [ ] Add the documentation label tag
- [ ] Add the bug / feature label tag
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments