### PR TITLE
Add `IBM DB2` migration

### DIFF
--- a/python/migrate.py
+++ b/python/migrate.py
@@ -346,6 +346,7 @@ mgp.add_batch_read_proc(postgresql, init_migrate_postgresql, cleanup_migrate_pos
 # IBM DB2 dictionary to store connections and cursors by thread
 db2_dict = {}
 
+
 def init_migrate_db2(
     table_or_sql: str,
     config: mgp.Map,
@@ -425,6 +426,7 @@ def cleanup_migrate_db2():
     ibm_db.close(db2_dict[threading.get_native_id][Constants.CONNECTION])
     db2_dict[threading.get_native_id][Constants.CONNECTION] = None
     db2_dict[threading.get_native_id][Constants.COLUMN_NAMES] = None
+
 
 mgp.add_batch_read_proc(db2, init_migrate_db2, cleanup_migrate_db2)
 

--- a/python/migrate.py
+++ b/python/migrate.py
@@ -464,3 +464,7 @@ def _check_params_type(params: Any, types=(dict, list, tuple)) -> None:
         raise TypeError(
             "Database query parameter values must be passed in a container of type List[Any] (or Map, if migrating from MySQL or Oracle DB)"
         )
+
+
+def _create_connection_string(config: mgp.Map) -> str:
+    return ";".join(f"{key}={value}" for key, value in config.items())

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -13,6 +13,6 @@ mysql-connector-python==8.0.32
 oracledb==1.2.2
 pyodbc==4.0.35
 psycopg2-binary==2.9.9
-ibm-db=3.2.3
+ibm-db==3.2.3
 defusedxml==0.7.1
 scipy==1.12.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -13,5 +13,6 @@ mysql-connector-python==8.0.32
 oracledb==1.2.2
 pyodbc==4.0.35
 psycopg2-binary==2.9.9
+ibm-db=3.2.3
 defusedxml==0.7.1
 scipy==1.12.0

--- a/python/requirements_no_ml.txt
+++ b/python/requirements_no_ml.txt
@@ -11,5 +11,6 @@ mysql-connector-python==8.0.32
 oracledb==1.2.2
 pyodbc==4.0.35
 psycopg2-binary==2.9.9
+ibm-db==3.2.3
 defusedxml==0.7.1
 scipy==1.12.0


### PR DESCRIPTION
New query module that migrates data from `IBM DB2` to Memgraph.