### PR TITLE
Fix building of newly created rust modules

### DIFF
--- a/setup
+++ b/setup
@@ -135,8 +135,6 @@ def get_arguments():
         default=MAGE_BUILD_DIRECTORY,
     )
 
-    
-
     return parser.parse_args()
 
 
@@ -245,7 +243,7 @@ def build_and_copy_cpp_modules(args: Dict[str, Any]) -> bool:
     return True
 
 
-def copy_python_modules(args:Dict[str,Any]) -> bool:
+def copy_python_modules(args: Dict[str, Any]) -> bool:
     """
     Function copies Python modules to MAGE_BUILD_DIRECTORY. Returns true if successful, otherwise false.
     """
@@ -256,7 +254,6 @@ def copy_python_modules(args:Dict[str,Any]) -> bool:
 
     os.chdir(PY_DIRECTORY)
 
-    
     ignore_list = [
         "tests",
         "requirements.txt",
@@ -285,10 +282,11 @@ def build_and_copy_rust_modules(args: Dict[str, Any]) -> bool:
 
     logger.info(f"[Terminal] (7/8) Building and copying Rust modules started.")
 
-    os.chdir(RS_DIRECTORY)
-    for project in filter(
-        lambda f: os.path.isdir(f) and f != "rsmgp-sys", os.listdir(RS_DIRECTORY)
-    ):
+    for project in os.listdir(RS_DIRECTORY):
+        os.chdir(RS_DIRECTORY)
+        if not os.path.isdir(project) or project == "rsmgp-sys":
+            continue
+
         project_dir = os.path.join(RS_DIRECTORY, project)
         os.chdir(project_dir)
         rs_build_mode = "release"
@@ -352,6 +350,7 @@ def build(args: Dict[str, Any]) -> bool:
             return False
 
     return True
+
 
 def run_build_action(args: Dict[str, Any]) -> bool:
     logger.info("[Terminal] Starting building and copying source code...")


### PR DESCRIPTION
### Description

New query modules could not be built in Rust because there was a logical error in the code.

### Pull request type

- [X] Bugfix
- [ ] Algorithm/Module
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Tests provided (unit / e2e)
- [ ] Code documentation
- [ ] README short description


### Documentation checklist
- [X] Add the documentation label tag
- [X] Add the bug / feature label tag
- [X] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [X] Write a release note, including added/changed clauses
    - **Fixed logical error when building new Rust query modules**
- [X] Link the documentation PR here
    - **No PR needed**
- [X] Tag someone from docs team in the comments @kgolubic 