### PR TITLE
Node2vec - enforce that either negative_rate or hs are positive

### DIFF
--- a/python/mage/node2vec_online_module/w2v_learners.py
+++ b/python/mage/node2vec_online_module/w2v_learners.py
@@ -48,7 +48,7 @@ class GensimWord2Vec:
                 "epochs": self.num_epochs,
                 "workers": self.threads,
             }
-            if self.negative_rate < 0:
+            if self.negative_rate <= 0:
                 self.negative_rate = 0
                 self.model = Word2Vec(
                     sentences, negative=self.negative_rate, hs=1, **params


### PR DESCRIPTION
### Description

Since we updated gensim from 4.0.0 to 4.3.3 the newer version requires that in Word2Vec either `hs` or `negative` is positive and we had an edge case where both of these variables would end up non positive and would result in the module throwing.

### Pull request type

- [x] Bugfix
- [x] Algorithm/Module
- [x] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] Documentation content changes
- [x] Other (please describe):

### Related issues

Delete if this PR doesn't resolve any issues. Link the issue if it does.

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Tests provided (unit / e2e)
- [ ] Code documentation
- [ ] README short description


### Documentation checklist
- [ ] Add the documentation label tag
- [ ] Add the bug / feature label tag
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments