### PR TITLE
Update elastic_search_serialization.py to allow connecting without passwords and ca-certs

### DIFF
--- a/python/elastic_search_serialization.py
+++ b/python/elastic_search_serialization.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, List, Dict, Tuple
+from typing import Any, List, Dict, Tuple, Union
 from datetime import datetime
 
 import elasticsearch
@@ -226,7 +226,7 @@ def elastic_search_parallel_bulk(
 
 @mgp.read_proc
 def connect(
-    elastic_url: str, ca_certs: str, elastic_user: str, elastic_password
+    elastic_url: str, ca_certs: Union[str, None]=None, elastic_user: str="", elastic_password: str=""
 ) -> mgp.Record(connection_status=mgp.Map):
     """Establishes connection with the Elasticsearch. This configuration needs to be specific to the Elasticsearch deployment. Uses basic authentication
     Args:


### PR DESCRIPTION
### Description

In elastic_search_serialization.py, generalised arguments that are passed to elasticsearch client to allow for more types of connection that the elasticsearch client supports. In particular, support connection over http without auth.

### Pull request type

- [X ] Bugfix
- [ ] Algorithm/Module
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Related issues

https://github.com/memgraph/mage/issues/496

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Tests provided (unit / e2e)
- [ ] Code documentation
- [ ] README short description


### Documentation checklist
- [ ] Add the documentation label tag
- [ ] Add the bug / feature label tag
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments