### PR TITLE
Allow read of data from elastic in later versions.

### DIFF
--- a/python/elastic_search_serialization.py
+++ b/python/elastic_search_serialization.py
@@ -570,8 +570,9 @@ def scan(
     )
     items = []
     for item in response:
-        item[ID] = item[_SOURCE][INDEX][ID]
-        item[_SOURCE].pop(INDEX, None)
+        if item[_SOURCE].get(INDEX, None):
+            item[ID] = item[_SOURCE][INDEX][ID]
+            item[_SOURCE].pop(INDEX, None)
         items.append(item)
 
     return mgp.Record(items=items)
@@ -608,8 +609,9 @@ def search(
     )
     hits = []
     for hit in response[HITS][HITS]:
-        hit[ID] = hit[_SOURCE][INDEX][ID]
-        hit[_SOURCE].pop(INDEX, None)
+        if hit[_SOURCE].get(INDEX, None):
+            hit[ID] = hit[_SOURCE][INDEX][ID]
+            hit[_SOURCE].pop(INDEX, None)
         hits.append(hit)
 
     result = {}


### PR DESCRIPTION
…

### Description

Update elastic_search_serialization.py only move around ID under _SOURCE if it ID exists. Tested on 8.14.3.

### Pull request type

- [X] Bugfix
- [ ] Algorithm/Module
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Related issues

https://github.com/memgraph/mage/issues/503

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Tests provided (unit / e2e)
- [ ] Code documentation
- [ ] README short description


### Documentation checklist
- [ ] Add the documentation label tag
- [ ] Add the bug / feature label tag
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments