### PR TITLE
Fix which memgraph package is pulled for dev rc builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
       build_scope: "${{ matrix.build_scope }}"
       memgraph_ref: "v${{ matrix.mg_version }}-${{ matrix.mg_rc_version }}"
       memgraph_ref_update: "false"
-      memgraph_download_link: "s3://deps.memgraph.io/memgraph/v${{ matrix.mg_version }}-${{ matrix.mg_rc_version }}/debian-11${{ matrix.arch == 'arm64' && '-aarch64' || '' }}/memgraph_${{ matrix.mg_version }}-1_${{ matrix.arch }}.deb"
+      memgraph_download_link: "s3://deps.memgraph.io/memgraph/v${{ matrix.mg_version }}-${{ matrix.mg_rc_version }}/debian-11${{ matrix.arch == 'arm64' && '-aarch64' || '' }}${{ matrix.build_scope == 'dev' && '-relwithdebinfo' || '' }}/memgraph_${{ matrix.mg_version }}-1_${{ matrix.arch }}.deb"
     secrets: inherit
 
   PR_test:


### PR DESCRIPTION
### Description

Fix the link for memgraph package which is pulled for dev rc builds

### Pull request type

- [ ] Bugfix
- [ ] Algorithm/Module
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Related issues

Delete if this PR doesn't resolve any issues. Link the issue if it does.

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Tests provided (unit / e2e)
- [ ] Code documentation
- [ ] README short description


### Documentation checklist
- [ ] Add the documentation label tag
- [ ] Add the bug / feature label tag
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments