### PR TITLE
Add pre-commit hook for black and flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+      - id: check-yaml
+
+  - repo: https://github.com/psf/black
+    rev: 22.3.0  # Should be the same as in python/tests/requirements.txt
+    hooks:
+      - id: black
+        args: [--quiet]
+        files: ^python/ 
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 3.9.2  # Should be the same as in python/tests/requirements.txt
+    hooks:
+      - id: flake8
+        args: [--config=python/.flake8]
+        files: ^python/ 

--- a/python/mage/tgn/definitions/tgn.py
+++ b/python/mage/tgn/definitions/tgn.py
@@ -421,11 +421,7 @@ class TGN(nn.Module):
 
             node_arr = []
             for v, t in cur_arr:
-                (
-                    neighbors,
-                    edge_idxs,
-                    timestamps,
-                ) = (
+                (neighbors, edge_idxs, timestamps,) = (
                     self.temporal_neighborhood.get_neighborhood(
                         v, t, self.num_neighbors
                     )
@@ -448,11 +444,7 @@ class TGN(nn.Module):
         global_edge_indexes = []
         global_timestamps = []
         for v, t in node_layers[0]:
-            (
-                neighbors,
-                edge_idxs,
-                timestamps,
-            ) = (
+            (neighbors, edge_idxs, timestamps,) = (
                 self.temporal_neighborhood.get_neighborhood(v, t, self.num_neighbors)
                 if (v, t) not in sampled_neighborhood
                 else sampled_neighborhood[(v, t)]


### PR DESCRIPTION
### Description

There was a different black version remote vs. locally. Added pre-commit hook which runs black and flake8 on python folder respecting configuration from pytest.ini

### Pull request type

- [ ] Bugfix
- [ ] Algorithm/Module
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Related issues

Delete if this PR doesn't resolve any issues. Link the issue if it does.

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Tests provided (unit / e2e)
- [ ] Code documentation
- [ ] README short description


### Documentation checklist
- [x] Add the documentation label tag
- [ ] Add the bug / feature label tag
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments