### PR TITLE
Fix bug in Leiden when no communities are found

### DIFF
--- a/e2e/leiden_community_detection_test/test_empty/test.yml
+++ b/e2e/leiden_community_detection_test/test_empty/test.yml
@@ -3,4 +3,4 @@ query: >
     RETURN node.id AS node_id, community_id, communities
     ORDER BY node_id ASC
 
-output: []
+exception: "No communities detected."


### PR DESCRIPTION
### Description

When no communities are found in some cases, algorithm results in segfault. This PR provides fix for this case.

### Pull request type

- [x] Bugfix
- [ ] Algorithm/Module
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Tests provided (unit / e2e)
- [ ] Code documentation
- [ ] README short description


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments