### PR TITLE
Bring back removed modules

### DIFF
--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -180,7 +180,7 @@ jobs:
         run: |
           cd e2e
           docker exec -i -u root ${{ env.MAGE_CONTAINER }} bash -c \
-          "cd /mage/e2e/ && python3 -m pytest . -k 'not cugraph and not node_classification and not link_prediction and not text ${{ inputs.build_scope == 'without ML' && 'and not tgn' || '' }}'"
+          "cd /mage/e2e/ && python3 -m pytest . -k 'not cugraph ${{ inputs.build_scope == 'without ML' && 'and not tgn' || '' }}'"
 
       - name: Run End-to-end correctness tests
         if: inputs.arch != 'arm64'

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -180,7 +180,7 @@ jobs:
         run: |
           cd e2e
           docker exec -i -u root ${{ env.MAGE_CONTAINER }} bash -c \
-          "cd /mage/e2e/ && python3 -m pytest . -k 'not cugraph ${{ inputs.build_scope == 'without ML' && 'and not tgn' || '' }}'"
+          cd /mage/e2e/ && python3 -m pytest . -k 'not cugraph ${{ inputs.build_scope == "without ML" && "and not node_classification and not link_prediction and not tgn" || "" }}'
 
       - name: Run End-to-end correctness tests
         if: inputs.arch != 'arm64'

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -180,7 +180,7 @@ jobs:
         run: |
           cd e2e
           docker exec -i -u root ${{ env.MAGE_CONTAINER }} bash -c \
-          cd /mage/e2e/ && python3 -m pytest . -k 'not cugraph ${{ inputs.build_scope == "without ML" && "and not node_classification and not link_prediction and not tgn" || "" }}'
+          "cd /mage/e2e/ && python3 -m pytest . -k 'not cugraph ${{ inputs.build_scope == 'without ML' && 'and not tgn and not node_classification and not link_prediction' || '' }}'"
 
       - name: Run End-to-end correctness tests
         if: inputs.arch != 'arm64'

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -68,12 +68,6 @@ RUN git clone --recurse-submodules -b 0.9.x https://github.com/dmlc/dgl.git  \
     && cd dgl && mkdir build && cd build && cmake .. \
     && make -j4 && cd ../python && python3 setup.py install
 
-# Needs to be here and in prod phase
-# Remove modules with issues
-RUN rm /usr/lib/memgraph/query_modules/node_classification.py \
-    && rm /usr/lib/memgraph/query_modules/link_prediction.py \
-    && rm /usr/lib/memgraph/query_modules/text.so
-
 USER memgraph
 ENTRYPOINT ["/usr/lib/memgraph/memgraph"]
 CMD [""]
@@ -103,7 +97,7 @@ RUN mv /mage/e2e /e2e/ \
     && export PATH="/usr/local/lib/python${PY_VERSION}:${PATH}" \
     && apt-get -y --purge autoremove clang git curl python3-pip python3-dev cmake build-essential \
     && apt-get clean
-    
+
 
 USER memgraph
 ENTRYPOINT ["/usr/lib/memgraph/memgraph"]


### PR DESCRIPTION
### Description

Making query modules removed under v1.14.1 (text, link prediction, node classification) available again.

### Pull request type

- [x] Bugfix
- [ ] Algorithm/Module
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Related issues

#471 
#470 
#469 
#448 

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Tests provided (unit / e2e)
- [ ] Code documentation
- [ ] README short description


### Documentation checklist
- [ ] Add the documentation label tag
- [ ] Add the bug / feature label tag
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Text, node classification and link prediction modules which were removed in v1.14.1 are brought back]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments