### PR TITLE
Fix export_util.py to encode in the UTF-8 

### DIFF
--- a/python/export_util.py
+++ b/python/export_util.py
@@ -796,7 +796,7 @@ def header_path(path: str):
 
 
 def write_file(path: str, delimiter: str, quoting_type: str, data: mgp.Any) -> None:
-    with open(path, "w") as file:
+    with open(path, "w", encoding="utf-8") as file:
         writer = csv.writer(
             file, delimiter=delimiter, quoting=quoting_type, escapechar="\\"
         )


### PR DESCRIPTION
### Description

The export_util can fail if special characters are not supported by default OS encoding. Specifying the version should help because  `UTF-8` should work universally on multiple systems. 

### Pull request type

- [x] Bugfix
- [ ] Algorithm/Module
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Related issues

Closes: #553 

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Tests provided (unit / e2e)
- [ ] Code documentation
- [ ] README short description


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **Set UTF-8 encoding in the export utility to support special characters **
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
- [ ] Tag someone from docs team in the comments