### PR TITLE
Use bash in docker container

### DIFF
--- a/Dockerfile.no_ML
+++ b/Dockerfile.no_ML
@@ -110,7 +110,7 @@ COPY memgraph-${TARGETARCH}.deb .
 
 # fix `memgraph` UID and GID for compatibility with previous Debian releases
 RUN groupadd -g 103 memgraph && \
-    useradd -u 101 -g memgraph -m -d /var/lib/memgraph memgraph && \
+    useradd -u 101 -g memgraph -m -d /var/lib/memgraph -s /bin/bash memgraph && \
     dpkg -i memgraph-${TARGETARCH}.deb && \
     rm memgraph-${TARGETARCH}.deb 
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -123,7 +123,7 @@ COPY memgraph-${TARGETARCH}.deb .
 
 # fix `memgraph` UID and GID for compatibility with previous Debian releases
 RUN groupadd -g 103 memgraph && \
-    useradd -u 101 -g memgraph -m -d /var/lib/memgraph memgraph && \
+    useradd -u 101 -g memgraph -m -d /var/lib/memgraph -s /bin/bash memgraph && \
     dpkg -i memgraph-${TARGETARCH}.deb && \
     rm memgraph-${TARGETARCH}.deb 
 


### PR DESCRIPTION
### Description

Minor change to set the user shell to `/bin/bash` for the `memgraph` user in line with previous releases
