### PR TITLE
Fix branch tags

### DIFF
--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -140,12 +140,20 @@ jobs:
 
       - name: Get Current MAGE Tag
         run: |
-          # Get the current tag, or commit hash if a tag doesn't exist
+          # Get the current tag, or branch if a tag doesn't exist
           # This is used later in image creation, so that the exact version of 
           # the MAGE git repository can be checked out within the container, 
           # when we run the script to convert to "dev" container
           tag=$(./get_tag.sh)
-          echo "Using tag/commit hash: $tag"
+
+          # If tag is empty, fallback to the branch name from GITHUB_REF
+          if [ -z "$tag" ]; then
+            echo "No valid tag found; using branch name."
+            # Remove the "refs/heads/" prefix to extract the branch name
+            tag="${GITHUB_REF#refs/heads/}"
+          fi
+
+          echo "Using tag/branch: $tag"
           echo "MAGE_COMMIT=${tag}" >> GITHUB_ENV
 
 

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -81,12 +81,20 @@ jobs:
           
       - name: Get Current MAGE Tag
         run: |
-          # Get the current tag, or commit hash if a tag doesn't exist
+          # Get the current tag, or branch if a tag doesn't exist
           # This is used later in image creation, so that the exact version of 
           # the MAGE git repository can be checked out within the container, 
           # when we run the script to convert to "dev" container
           tag=$(./get_tag.sh)
-          echo "Using tag/commit hash: $tag"
+
+          # If tag is empty, fallback to the branch name from GITHUB_REF
+          if [ -z "$tag" ]; then
+            echo "No valid tag found; using branch name."
+            # Remove the "refs/heads/" prefix to extract the branch name
+            tag="${GITHUB_REF#refs/heads/}"
+          fi
+
+          echo "Using tag/branch: $tag"
           echo "MAGE_COMMIT=${tag}" >> GITHUB_ENV
 
 

--- a/get_tag.sh
+++ b/get_tag.sh
@@ -5,7 +5,7 @@ tag=$(git tag --points-at HEAD)
 
 # If no tag is found, fall back to the current commit hash
 if [ -z "$tag" ]; then
-    tag=$(git rev-parse HEAD)
+    tag=""
 fi
 
 echo "$tag"

--- a/make-dev-container.sh
+++ b/make-dev-container.sh
@@ -47,7 +47,22 @@ echo "Cloning MAGE repo commit/tag: $MAGE_COMMIT"
 cd /root
 git clone https://github.com/memgraph/mage.git --recurse-submodules
 cd /root/mage
-git checkout $MAGE_COMMIT
+
+# Check if MAGE_COMMIT matches a version tag format: vX.Y or vX.Y.Z
+if [[ "$MAGE_COMMIT" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+    echo "Detected valid tag format. Checking out tag: $MAGE_COMMIT"
+    git checkout "$MAGE_COMMIT"
+else
+    echo "Detected branch name. Checking out branch: $MAGE_COMMIT"
+    git checkout "$MAGE_COMMIT"
+    
+    echo "Fetching latest main branch..."
+    git fetch origin main
+
+    echo "Merging origin/main into branch $MAGE_COMMIT..."
+    git merge origin/main
+fi
+
 cd /
 
 echo "Copying repo files to /mage"


### PR DESCRIPTION
### Description

Fix an error in CI due to collecting the wrong commit hash. Instead of checkout out a commit hash, it should either checkout a tag, otherwise the branch name (then merge with `main`).
