### PR TITLE
Add gdb and full mage repo to relwithdebinfo image

### DIFF
--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -224,9 +224,16 @@ jobs:
           echo "Using base image: $MGBUILD_IMAGE"
           echo "Image Tag: ${{ env.IMAGE_TAG }}"
 
-          # target is always "prod" now, we convert to dev container afterwards
+          # target is "prod" for Release and "debug" for RelWithDebInfo
+          if [ "${{ env.MAGE_BUILD_TYPE }}" = "RelWithDebInfo" ]; then
+            DOCKER_TARGET=debug
+          else
+            DOCKER_TARGET=prod
+          fi
+          echo "Using target: $DOCKER_TARGET"
+
           docker buildx build \
-          --target prod \
+          --target $DOCKER_TARGET \
           --platform linux/${{ inputs.arch }} \
           --tag ${DOCKER_REPOSITORY_NAME}:${{ env.IMAGE_TAG }} \
           --file ${{ env.DOCKERFILE }} \

--- a/Dockerfile.no_ML
+++ b/Dockerfile.no_ML
@@ -68,7 +68,7 @@ RUN source /opt/toolchain-v6/activate && curl https://sh.rustup.rs -sSf | sh -s 
 # Memgraph listens for Bolt Protocol on this port by default.
 EXPOSE 7687
 
-FROM ubuntu:24.04 as prod
+FROM ubuntu:24.04 as base
 
 USER root
 
@@ -124,6 +124,28 @@ COPY --from=builder /usr/lib/memgraph/auth_module/ /usr/lib/memgraph/auth_module
 COPY --from=builder /usr/local/lib/python${PY_VERSION}/ /usr/local/lib/python${PY_VERSION}/
 COPY --from=builder --chown=memgraph:memgraph /var/lib/memgraph/.local/ /var/lib/memgraph/.local/ 
 
+# copy script to convert to dev container
+COPY --from=builder /mage/make-dev-container.sh /make-dev-container.sh
+
+USER memgraph
+EXPOSE 7687
+
+ENTRYPOINT ["/usr/lib/memgraph/memgraph"]
+CMD [""]
+
+
+FROM base as prod
+
+USER root
+
+ARG TARGETARCH
+ARG PY_VERSION_DEFAULT=3.12
+ARG MAGE_COMMIT
+ARG BUILD_TYPE
+ENV BUILD_TYPE=${BUILD_TYPE}
+ENV PY_VERSION ${PY_VERSION_DEFAULT}
+ENV MAGE_COMMIT=${MAGE_COMMIT}
+
 #copy e2e tests
 COPY --from=builder --chown=memgraph:memgraph /mage/e2e/ /mage/e2e/
 COPY --from=builder --chown=memgraph:memgraph /mage/e2e_correctness/ /mage/e2e_correctness/
@@ -134,8 +156,33 @@ COPY --from=builder --chown=memgraph:memgraph /mage/run_e2e_correctness_tests.sh
 COPY --from=builder --chown=memgraph:memgraph /mage/python/requirements_no_ml.txt /mage/python/requirements_no_ml.txt
 COPY --from=builder --chown=memgraph:memgraph /mage/python/tests/requirements.txt /mage/python/tests/requirements.txt 
 
-# copy script to convert to dev container
-COPY --from=builder /mage/make-dev-container.sh /make-dev-container.sh
+USER memgraph
+EXPOSE 7687
+
+ENTRYPOINT ["/usr/lib/memgraph/memgraph"]
+CMD [""]
+
+
+FROM base as debug
+
+USER root
+
+ARG TARGETARCH
+ARG PY_VERSION_DEFAULT=3.12
+ARG MAGE_COMMIT
+ARG BUILD_TYPE
+ENV BUILD_TYPE=${BUILD_TYPE}
+ENV PY_VERSION ${PY_VERSION_DEFAULT}
+ENV MAGE_COMMIT=${MAGE_COMMIT}
+
+# Add gdb
+RUN apt-get update && apt-get install -y \
+    gdb \
+    --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
+
+# Copy entire mage repo
+COPY --from=builder --chown=memgraph:memgraph /mage/ /mage/
 
 USER memgraph
 EXPOSE 7687

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -81,7 +81,8 @@ RUN source /opt/toolchain-v6/activate && curl https://sh.rustup.rs -sSf | sh -s 
 EXPOSE 7687
 
 
-FROM ubuntu:24.04 as prod
+
+FROM ubuntu:24.04 as base
 
 USER root
 
@@ -137,6 +138,21 @@ COPY --from=builder /usr/lib/memgraph/auth_module/ /usr/lib/memgraph/auth_module
 COPY --from=builder /usr/local/lib/python${PY_VERSION}/ /usr/local/lib/python${PY_VERSION}/
 COPY --from=builder --chown=memgraph:memgraph /var/lib/memgraph/.local/ /var/lib/memgraph/.local/ 
 
+# copy script to convert to dev container
+COPY --from=builder /mage/make-dev-container.sh /make-dev-container.sh
+
+FROM base as prod
+
+USER root
+
+ARG TARGETARCH
+ARG PY_VERSION_DEFAULT=3.12
+ARG MAGE_COMMIT
+ARG BUILD_TYPE
+ENV BUILD_TYPE=${BUILD_TYPE}
+ENV PY_VERSION ${PY_VERSION_DEFAULT}
+ENV MAGE_COMMIT=${MAGE_COMMIT}
+
 # Copy e2e tests
 COPY --from=builder --chown=memgraph:memgraph /mage/e2e/ /mage/e2e/
 COPY --from=builder --chown=memgraph:memgraph /mage/e2e_correctness/ /mage/e2e_correctness/
@@ -147,8 +163,34 @@ COPY --from=builder --chown=memgraph:memgraph /mage/run_e2e_correctness_tests.sh
 COPY --from=builder --chown=memgraph:memgraph /mage/python/requirements.txt /mage/python/requirements.txt
 COPY --from=builder --chown=memgraph:memgraph /mage/python/tests/requirements.txt /mage/python/tests/requirements.txt 
 
-# copy script to convert to dev container
-COPY --from=builder /mage/make-dev-container.sh /make-dev-container.sh
+USER memgraph
+EXPOSE 7687
+
+ENTRYPOINT ["/usr/lib/memgraph/memgraph"]
+CMD [""]
+
+
+FROM base as debug
+
+USER root
+
+ARG TARGETARCH
+ARG PY_VERSION_DEFAULT=3.12
+ARG MAGE_COMMIT
+ARG BUILD_TYPE
+ENV BUILD_TYPE=${BUILD_TYPE}
+ENV PY_VERSION ${PY_VERSION_DEFAULT}
+ENV MAGE_COMMIT=${MAGE_COMMIT}
+
+
+# Add gdb
+RUN apt-get update && apt-get install -y \
+    gdb \
+    --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 
+
+# Copy entire mage repo
+COPY --from=builder --chown=memgraph:memgraph /mage/ /mage/
 
 USER memgraph
 EXPOSE 7687


### PR DESCRIPTION
Modified dockerfiles to add a `debug` stage which installs `gdb` and the full MAGE repo within the image for the RelWithDebInfo build.
