### PR TITLE
Shorten MAGE image tags

### DIFF
--- a/.github/workflows/promote_rc_release.yaml
+++ b/.github/workflows/promote_rc_release.yaml
@@ -14,10 +14,6 @@ on:
         description: "Mage RC version to promote (format: rcX)"
         required: false
         type: string
-      memgraph_version:
-        description: "Memgraph version (format: X.Y.Z)"
-        required: true
-        type: string
       force_promote:
         type: boolean
         description: "Override existing release"
@@ -53,11 +49,10 @@ jobs:
       - name: Setup environment variables
         run: |
           mage_version=${{ github.event.inputs.mage_version }}
-          memgraph_version=${{ github.event.inputs.memgraph_version }}
-          echo "docker_tar_amd=mage-${mage_version%.0}-memgraph-${memgraph_version%.0}${{ matrix.image_ext }}.tar.gz" >> $GITHUB_ENV
-          echo "docker_tar_arm=mage-${mage_version%.0}-memgraph-${memgraph_version%.0}-arm64${{ matrix.image_ext }}.tar.gz" >> $GITHUB_ENV
-          echo "rc_image=${docker_repo_rc}:${mage_version%.0}-memgraph-${memgraph_version%.0}${{ matrix.image_ext }}" >> $GITHUB_ENV
-          echo "release_image=${docker_repo_release}:${mage_version%.0}-memgraph-${memgraph_version%.0}${{ matrix.image_ext }}" >> $GITHUB_ENV
+          echo "docker_tar_amd=mage-${mage_version%.0}${{ matrix.image_ext }}.tar.gz" >> $GITHUB_ENV
+          echo "docker_tar_arm=mage-${mage_version%.0}-arm64${{ matrix.image_ext }}.tar.gz" >> $GITHUB_ENV
+          echo "rc_image=${docker_repo_rc}:${mage_version%.0}${{ matrix.image_ext }}" >> $GITHUB_ENV
+          echo "release_image=${docker_repo_release}:${mage_version%.0}${{ matrix.image_ext }}" >> $GITHUB_ENV
           
       - name: Setup S3 Paths
         run: |

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -109,7 +109,15 @@ jobs:
               MAGE_VERSION=${MAGE_VERSION%.*}
             fi
           fi
-          IMAGE_TAG="${MAGE_VERSION}-memgraph-${MEMGRAPH_VERSION}"
+
+          # if these match, then tag the image with the shortest vesion, e.g. 3.1.1
+          # rather than 3.1.1-memgraph-3.1.1, hopefully this won't affect the
+          # daily build versioning, which will still be massive
+          if [[ "$MAGE_VERSION" == "$MEMGRAPH_VERSION" ]]; then
+            IMAGE_TAG="${MAGE_VERSION}"
+          else
+            IMAGE_TAG="${MAGE_VERSION}-memgraph-${MEMGRAPH_VERSION}"
+          fi
           IMAGE_TAG="${IMAGE_TAG//+/_}"
           IMAGE_TAG="${IMAGE_TAG//\~/_}"
           ARTIFACT_NAME="mage-${IMAGE_TAG}"


### PR DESCRIPTION
Until now the tag for a MAGE image has indicate both the MAGE and Memgraph versions, e.g. `3.1.1-memgraph-3.1.1`. The versions of both MAGE and Memgraph are now locked together, rendering this format somewhat redundant. This PR aims to change the tag to be like `3.1.1` or `3.1.1-relwithdebinfo`.
