### PR TITLE
Fix event_name check

### DIFF
--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -42,7 +42,7 @@ jobs:
         id: compute
         run: |
           # Pass the client payload (as JSON) to the Python script.
-          if [ "${{ github.ref_type }}" == "repository_dispatch" ]; then
+          if [ "${{ github.event_name }}" == "repository_dispatch" ]; then
             payload='${{ toJson(github.event.client_payload) }}'
           else
             # Check if the 'date' input is empty; if so, compute today's date in YYYYMMDD format.


### PR DESCRIPTION
Fixes daily build workflow by checking the correct GitHub variable name for `repository_dispatch` in order to use the `$payload` provided by the Memgraph daily build workflow.