### PR TITLE
Fix MAGE packaging workflow so it uses package cache

### DIFF
--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -72,10 +72,22 @@ jobs:
 
       - name: Check mgdeps-cache availability
         run: |
-          if curl -I --silent --fail "http://mgdeps-cache:8000/wheels"; then
-            echo "mgdeps-cache is reachable"
+          if curl --silent --fail "http://mgdeps-cache:8000/wheels/" -o /dev/null; then
+            echo "mgdeps-cache is reachable :D"
+            echo "CACHE_PRESENT=true" >> $GITHUB_ENV
           else
             echo "mgdeps-cache is NOT reachable"
+            echo "CACHE_PRESENT=false" >> $GITHUB_ENV
+          fi
+
+      - name: Create wheels directory and fetch wheels if available
+        run: |
+          mkdir -p wheels
+          if [ "$CACHE_PRESENT" = "true" ]; then
+            echo "Cache is present. Fetching wheels..."
+            wget -r -np -nH --cut-dirs=1 -P wheels "http://mgdeps-cache:8000/wheels/"
+          else
+            echo "Cache is not present. Skipping wheel fetch."
           fi
 
       - name: Set up Docker Buildx
@@ -234,6 +246,7 @@ jobs:
           --build-arg BUILD_TYPE=${{ env.MAGE_BUILD_TYPE }} \
           --build-arg MGBUILD_IMAGE=$MGBUILD_IMAGE \
           --build-arg MAGE_COMMIT="${{ env.MAGE_COMMIT }}" \
+          --build-arg CACHE_PRESENT=${{ env.CACHE_PRESENT }} \
           --load .
 
           # print the image size in both SI and IEC units


### PR DESCRIPTION
The `reusable_package_mage.yaml` workflow is missing some steps which speed up the equivalent parts of `reusable_test.yaml` by using cache Python packages (this affects ARM significantly more than x86 builds). Should speed up packaging MAGE for ARM by about 30 minutes.
