### PR TITLE
Fix memgraph package download from S3 flakiness

### DIFF
--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -213,30 +213,8 @@ jobs:
             mg_url=${{ inputs.memgraph_download_link }}
           fi
 
-          # retry loop
-          max_attempts=3
-          attempt=1
-
-          while (( attempt <= max_attempts )); do
-            echo "Attempt #${attempt}: checking ${mg_url}"
-            if curl --silent --head --fail --max-time 60 "$mg_url" >/dev/null; then
-              echo "Memgraph download link is valid on attempt #${attempt}"
-              echo "MEMGRAPH_DOWNLOAD_LINK=${mg_url}" >> $GITHUB_ENV
-              break
-            else
-              echo "Attempt #${attempt} failed."
-              if (( attempt < max_attempts )); then
-                echo "waiting 20s before retry..."
-                sleep 20
-              fi
-              (( attempt++ ))
-            fi
-          done
-
-          if (( attempt > max_attempts )); then
-            echo "Memgraph download link is not valid after ${max_attempts} attempts — exiting."
-            exit 1
-          fi
+          ./scripts/verify_download_link "$mg_url"
+          echo "MEMGRAPH_DOWNLOAD_LINK=${mg_url}" >> $GITHUB_ENV
 
 
       - name: Download memgraph binary

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -212,13 +212,32 @@ jobs:
             echo "Using custom download link"
             mg_url=${{ inputs.memgraph_download_link }}
           fi
-          if curl --output /dev/null --silent --head --fail $mg_url; then
-            echo "Memgraph download link is valid"
-            echo "MEMGRAPH_DOWNLOAD_LINK=${mg_url}" >> $GITHUB_ENV 
-          else
-            echo "Memgraph download link is not valid"
+
+          # retry loop
+          max_attempts=3
+          attempt=1
+
+          while (( attempt <= max_attempts )); do
+            echo "Attempt #${attempt}: checking ${mg_url}"
+            if curl --silent --head --fail --max-time 60 "$mg_url" >/dev/null; then
+              echo "Memgraph download link is valid on attempt #${attempt}"
+              echo "MEMGRAPH_DOWNLOAD_LINK=${mg_url}" >> $GITHUB_ENV
+              break
+            else
+              echo "Attempt #${attempt} failed."
+              if (( attempt < max_attempts )); then
+                echo "waiting 20s before retry..."
+                sleep 20
+              fi
+              (( attempt++ ))
+            fi
+          done
+
+          if (( attempt > max_attempts )); then
+            echo "Memgraph download link is not valid after ${max_attempts} attempts — exiting."
             exit 1
           fi
+
 
       - name: Download memgraph binary
         run: curl -L ${{ env.MEMGRAPH_DOWNLOAD_LINK }} > memgraph-${{ inputs.arch }}.deb

--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -213,7 +213,7 @@ jobs:
             mg_url=${{ inputs.memgraph_download_link }}
           fi
 
-          ./scripts/verify_download_link "$mg_url"
+          ./scripts/verify_download_url.sh "$mg_url"
           echo "MEMGRAPH_DOWNLOAD_LINK=${mg_url}" >> $GITHUB_ENV
 
 

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -155,11 +155,28 @@ jobs:
             echo "MEMGRAPH_S3_URI=${mg_url}" >> $GITHUB_ENV
           elif [[ $url_protocol == "https" ]]; then
             echo "Checking if the https link is valid"
-            if curl --output /dev/null --silent --head --fail $mg_url; then
-              echo "Memgraph download link is valid"
-              echo "MEMGRAPH_OBJECT_URL=${mg_url}" >> $GITHUB_ENV 
-            else
-              echo "Memgraph download link is not valid"
+            # retry loop
+            max_attempts=3
+            attempt=1
+
+            while (( attempt <= max_attempts )); do
+              echo "Attempt #${attempt}: checking ${mg_url}"
+              if curl --silent --head --fail --max-time 60 "$mg_url" >/dev/null; then
+                echo "Memgraph download link is valid on attempt #${attempt}"
+                echo "MEMGRAPH_OBJECT_URL=${mg_url}" >> $GITHUB_ENV
+                break
+              else
+                echo "Attempt #${attempt} failed."
+                if (( attempt < max_attempts )); then
+                  echo "waiting 20s before retry..."
+                  sleep 20
+                fi
+                (( attempt++ ))
+              fi
+            done
+
+            if (( attempt > max_attempts )); then
+              echo "Memgraph download link is not valid after ${max_attempts} attempts — exiting."
               exit 1
             fi
           else

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -154,31 +154,8 @@ jobs:
           if [[ $url_protocol == "s3" ]]; then
             echo "MEMGRAPH_S3_URI=${mg_url}" >> $GITHUB_ENV
           elif [[ $url_protocol == "https" ]]; then
-            echo "Checking if the https link is valid"
-            # retry loop
-            max_attempts=3
-            attempt=1
-
-            while (( attempt <= max_attempts )); do
-              echo "Attempt #${attempt}: checking ${mg_url}"
-              if curl --silent --head --fail --max-time 60 "$mg_url" >/dev/null; then
-                echo "Memgraph download link is valid on attempt #${attempt}"
-                echo "MEMGRAPH_OBJECT_URL=${mg_url}" >> $GITHUB_ENV
-                break
-              else
-                echo "Attempt #${attempt} failed."
-                if (( attempt < max_attempts )); then
-                  echo "waiting 20s before retry..."
-                  sleep 20
-                fi
-                (( attempt++ ))
-              fi
-            done
-
-            if (( attempt > max_attempts )); then
-              echo "Memgraph download link is not valid after ${max_attempts} attempts — exiting."
-              exit 1
-            fi
+            ./scripts/verify_download_link "$mg_url"
+            echo "MEMGRAPH_OBJECT_URL=${mg_url}" >> $GITHUB_ENV
           else
             echo "Invalid download link protocol, only supporting s3:// and https://"
             exit 1

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -154,7 +154,7 @@ jobs:
           if [[ $url_protocol == "s3" ]]; then
             echo "MEMGRAPH_S3_URI=${mg_url}" >> $GITHUB_ENV
           elif [[ $url_protocol == "https" ]]; then
-            ./scripts/verify_download_link "$mg_url"
+            ./scripts/verify_download_url.sh "$mg_url"
             echo "MEMGRAPH_OBJECT_URL=${mg_url}" >> $GITHUB_ENV
           else
             echo "Invalid download link protocol, only supporting s3:// and https://"

--- a/scripts/verify_download_url.sh
+++ b/scripts/verify_download_url.sh
@@ -6,7 +6,7 @@ usage() {
   exit 1
 }
 
-if [[ $# -lt 4 ]]; then
+if [[ $# -lt 1 ]]; then
   usage
 fi
 

--- a/scripts/verify_download_url.sh
+++ b/scripts/verify_download_url.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <url>" >&2
+  exit 1
+}
+
+if [[ $# -lt 4 ]]; then
+  usage
+fi
+
+url="$1"
+
+echo "Verifying download URL: $url"
+
+# Verify with curl retry
+if curl --silent --head --fail --max-time 60 --retry 3 --retry-delay 20 "$url" >/dev/null; then
+  echo "Download link is valid"
+else
+  echo "Download link is not valid"
+  exit 1
+fi


### PR DESCRIPTION
Add a retry loop to the URL validity check in case the package isn't available yet.

