### PR TITLE
Update e2e tests for GQLAlchemy 1.8.0

### DIFF
--- a/e2e/test_module.py
+++ b/e2e/test_module.py
@@ -299,14 +299,5 @@ def test_end2end(test_dir: Path, db: Memgraph):
 
     # Clean database once testing module is finished
     db.drop_database()
-
-    # TODO (matt): this should be removed once gqlalchemy has been updated
-    indexes = db.execute_and_fetch("SHOW INDEX INFO")
-    for index in indexes:
-        if index["index type"] == "label+property":
-            for property in index["property"]:
-                db.execute(f"DROP INDEX ON :{index['label']}({property})")
-
     db.drop_indexes()
     db.ensure_constraints([])
-   

--- a/python/tests/requirements.txt
+++ b/python/tests/requirements.txt
@@ -9,4 +9,4 @@ pytest-cov==6.0.0
 pytest-benchmark==5.1.0
 pytest-flake8==1.3.0
 pytest-black==0.6.0
-gqlalchemy==1.6.0
+gqlalchemy==1.8.0


### PR DESCRIPTION
Removed workaround in E2E tests for dropping indices using older versions of `gqlalchemy`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the `gqlalchemy` package to version 1.8.0 in test requirements.
  - Cleaned up test code by removing obsolete commented-out logic related to index management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->