### PR TITLE
Update workflow concurrency groups to avoid conflicts

### DIFF
--- a/.github/workflows/cve_scan.yml
+++ b/.github/workflows/cve_scan.yml
@@ -1,6 +1,6 @@
 name: Vulnerability Scan
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: cve-scan-${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -1,6 +1,6 @@
 name: 'Create Daily Build'
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: daily-build-${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/manual_cve_scan.yml
+++ b/.github/workflows/manual_cve_scan.yml
@@ -1,6 +1,6 @@
 name: Manual Vulnerability Scan
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: manual-cve-scan-${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/promote_rc_release.yaml
+++ b/.github/workflows/promote_rc_release.yaml
@@ -1,6 +1,6 @@
 name: Promote RC to Release
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: promote-rc-${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/release_artifacts.yaml
+++ b/.github/workflows/release_artifacts.yaml
@@ -1,6 +1,6 @@
 name: 'Create release artifacts'
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: release-artifacts-${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -1,6 +1,6 @@
 name: "Smoke Testing"
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}
+  group: smoke-tests-${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Build and Test
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event_name }}
+  group: build-and-test-${{ github.workflow }}-${{ github.ref_name }}-${{ github.event_name }}
   cancel-in-progress: true
 
 on: 


### PR DESCRIPTION
Weekly CVE scan is blocked from running due to a conflict in the concurrency group name with the daily build workflow that triggers it. This fix should stop unrelated jobs from cancelling/conflicting with each other.
