### PR TITLE
Fix CVE scan false positive

### DIFF
--- a/scripts/scan_languages.py
+++ b/scripts/scan_languages.py
@@ -1,11 +1,8 @@
-from cve_bin_tool.log import LOGGER
-from cve_bin_tool.cvedb import CVEDB
 from cve_bin_tool.parsers.parse import valid_files as cbt_valid_files
 import os
 import subprocess
 import argparse
-from typing import List
-import json
+
 
 """
 This script should speed up the scanning for specific programming-language
@@ -15,60 +12,23 @@ This script doe the following:
 1. Walks the extracted root filesystem of the container searching for package
 metadata files which cve-bin-tool would normally look for (`valid_files`).
 
-2. Uses cve-bin-tool's language parsing functions to extract the `vendor`, 
-`product` and `version` from the metadata files for each installed package.
+2. Copies these files to a separate directory structure so that cve-bin-tool
+   does not have to scan the entire root filesystem, which can be very slow.
 
-3. Saves a CSV with the columns `vendor`, `product` and `version`.
-
-4. Calls cve-bin-tool with the `--input-file` (`-i`) argument pointing to the
-CSV file. This will do a direct database lookup for each product, vendor and
-version, rather than scanning the iamge itself. The output is a JSON file
-containing all CVEs for those installed packages.
+3. Runs cve-bin-tool on the copied files, using a triage file to filter out
+   false positives, and outputs the results to a JSON file.
 """
 
 CVE_DIR = os.getenv("CVE_DIR", os.getcwd())
 
 
-def list_language_files() -> tuple[dict[str, list[str]], dict[str, list[type]]]:
-    """
-    Return a dictionaries mapping language names to files which cve-bin-tool checks
-    and a dictionary mapping file names to the cve-bin-tool checkers.
-    
-    Returns
-    =======
-    language_files: dict[str, list[str]]
-        A dictionary mapping language names to lists of file names that cve-bin-tool checks.
-    file_checkers: dict[str, list[type]]
-        A dictionary mapping file names to lists of cve-bin-tool parser classes that check those files
-    """
-
-    # file_checkers is a dict mapping file names to the cve-bin-tool checkers
-    file_checkers = cbt_valid_files.copy()
-    file_checkers["METADATA"] = file_checkers["METADATA: "]
-    file_checkers["PKG-INFO"] = file_checkers["PKG-INFO: "]
-
-
-    # This is a dict mapping language name to files which cve-bin-tool checks
-    language_files = {}
-    for key, value in file_checkers.items():
-        # get the name of the language from the module name
-        # e.g. "cve_bin_tool.parsers.python.PythonParser" -> "python"
-        module_name = value[0].__module__
-        language = module_name.split(".")[-1]
-        if language not in language_files:
-            language_files[language] = []
-        language_files[language].append(key)
-
-    return language_files, file_checkers
-
-
-def find_files(root_dir: str) -> list[str]:
+def find_files(rootfs: str) -> list[str]:
     """
     Find all language files that CVE-bin-tool scans
 
     Inputs
     ======
-    root_dir: str
+    rootfs: str
         The root directory to search for language files
 
     Returns
@@ -77,64 +37,44 @@ def find_files(root_dir: str) -> list[str]:
         A list of paths to metadata files for language packages
     """
 
-    matches = {}
-    language_files, file_checkers = list_language_files()
-    for language in language_files:
-        matches[language] = []
-        for dirpath, _, filenames in os.walk(root_dir):
-            for filename in filenames:
-                if filename in language_files[language] and filename != "requirements.txt":
-                    matches[language].append((f"{dirpath}/{filename}", file_checkers[filename]))
+    file_checkers = cbt_valid_files.copy()
+    file_checkers["METADATA"] = file_checkers["METADATA: "]
+    file_checkers["PKG-INFO"] = file_checkers["PKG-INFO: "]
+    language_files = list(file_checkers.keys())
+
+    matches = []
+    for dirpath, _, filenames in os.walk(rootfs):
+        for filename in filenames:
+            if filename in language_files and filename != "requirements.txt":
+                matches.append(f"{dirpath}/{filename}")
     return matches
 
 
-def write_language_csvs(rootfs: str, language_files: List[str]) -> None:
+def copy_language_files(rootfs: str, langfs: str):
     """
-    Write a CSV file of all language packages found
-
-    Inputs
-    ======
-    rootfs: str
-        The path to the root filesystem of a container
+    Copy language files from the root filesystem to a language-specific
+    directory structure to avoid scanning everything in the rootfs.
     """
-    cve_db = CVEDB()
-    logger = LOGGER.getChild("Fuzz")
 
-    print(f"Collecting product, vendor and version information from language files...")
-    for language, file_list in language_files.items():
-        if len(file_list) > 0:
-            print(f"Found {len(file_list)} Language Files ({language})")
+    language_files = find_files(rootfs)
 
-            with open(f"{CVE_DIR}/lang-{language}-packages.csv", "w") as f:
-                f.write("vendor,product,version\n")
-                for file, parserclslist in file_list:
-                    for parsercls in parserclslist:
-                        parser = parsercls(cve_db, logger)
-
-                        output = parser.run_checker(file)
-                        for out in output:
-                            items = (out.product_info.vendor, out.product_info.product, out.product_info.version)
-                            f.write(f"{','.join(items)}\n")
-
-                print(f"Saved lang-{language}-packages.csv")
-
-    # cve_db does unusual things when it exists, so let's catch it
-    try:
-        del cve_db
-    except Exception:
-        pass
+    for file in language_files:
+        dir = os.path.dirname(file).replace(rootfs, langfs)
+        if not os.path.exists(dir):
+            os.makedirs(dir)
+        os.system(f"cp {file} -v {dir}")
 
 
-def run_language_scan(language: str) -> str:
+def run_language_scan(langfs: str) -> str:
     """
     Scan the CVE database using the list of language packages found and save the
     results to a JSON file.
 
     Inputs
     =======
-    language: str
-        The name of the programming language to scan (e.g., "python", "ruby", "nodejs", etc.)
-    
+    langfs: str
+        The directory containing the language package metadata files.
+
     Returns
     =======
     str
@@ -142,17 +82,16 @@ def run_language_scan(language: str) -> str:
         If the file does not exist, an empty string is returned.
     """
 
-    print(f"Scanning Language Packages ({language})...")
-    fname = f"{CVE_DIR}/lang-{language}-packages.csv"
-    if not os.path.exists(fname):
-        print(f"File {fname} does not exist. Skipping scan for {language}.")
-        return ""
+    print("Scanning Language Packages...")
+    outfile = f"{CVE_DIR}/cve-bin-tool-lang-summary.json"
+
     cmd = [
         "cve-bin-tool",
         "-u", "never",       # Never update the local CVE database
         "-f", "json",        # Output format: JSON
-        "-o", f"{CVE_DIR}/cve-bin-tool-lang-{language}-summary.json",   # Write JSON results to this file
-        "-i", fname
+        "-o", outfile,       # Write JSON results to this file
+        f"{langfs}/",
+        "--vex-file", "triage.json", "--filter-triage"  # Use the triage file to filter false positives
     ]
     _ = subprocess.run(
         cmd,
@@ -162,45 +101,15 @@ def run_language_scan(language: str) -> str:
     )
     # do not try to do anything clever with the result.returncode here, because
     # it only ever returns 0 if there are 0 vulnerabilities!
-    return fname
+    return outfile
 
-
-def scan_languages(languages) -> None:
-    """
-    Scan all languages found in the root filesystem for CVEs.
-
-    Inputs
-    =======
-    languages: list[str]
-        A list of programming languages to scan (e.g., ["python", "ruby", "nodejs", ...])
-
-    """
-
-    cve_files = []
-    for language in languages:
-        cve_file = run_language_scan(language)
-        if cve_file:
-            cve_files.append(cve_file)
-
-    # collect all the results into a single file
-    print("Collecting all results into a single file...")
-    cve_data = []
-    for file in cve_files:
-        with open(file, "r") as f:
-            data = json.load(f)
-            cve_data.extend(data)
-
-    with open(f"{CVE_DIR}/cve-bin-tool-lang-summary.json", "w") as f:
-        json.dump(cve_data, f, indent=2)
-        
 
 def main(rootfs: str) -> None:
     """
     Scan the root filesystem for CVEs in the language packages.
     """
-    language_files = find_files(rootfs)
-    write_language_csvs(rootfs, language_files)
-    scan_languages(list(language_files.keys()))
+    copy_language_files(rootfs, f"{CVE_DIR}/langfs")
+    run_language_scan(f"{CVE_DIR}/langfs")
 
 
 if __name__ == "__main__":

--- a/scripts/scan_languages.py
+++ b/scripts/scan_languages.py
@@ -4,6 +4,8 @@ from cve_bin_tool.parsers.parse import valid_files as cbt_valid_files
 import os
 import subprocess
 import argparse
+from typing import List
+import json
 
 """
 This script should speed up the scanning for specific programming-language
@@ -27,6 +29,39 @@ containing all CVEs for those installed packages.
 CVE_DIR = os.getenv("CVE_DIR", os.getcwd())
 
 
+def list_language_files() -> tuple[dict[str, list[str]], dict[str, list[type]]]:
+    """
+    Return a dictionaries mapping language names to files which cve-bin-tool checks
+    and a dictionary mapping file names to the cve-bin-tool checkers.
+    
+    Returns
+    =======
+    language_files: dict[str, list[str]]
+        A dictionary mapping language names to lists of file names that cve-bin-tool checks.
+    file_checkers: dict[str, list[type]]
+        A dictionary mapping file names to lists of cve-bin-tool parser classes that check those files
+    """
+
+    # file_checkers is a dict mapping file names to the cve-bin-tool checkers
+    file_checkers = cbt_valid_files.copy()
+    file_checkers["METADATA"] = file_checkers["METADATA: "]
+    file_checkers["PKG-INFO"] = file_checkers["PKG-INFO: "]
+
+
+    # This is a dict mapping language name to files which cve-bin-tool checks
+    language_files = {}
+    for key, value in file_checkers.items():
+        # get the name of the language from the module name
+        # e.g. "cve_bin_tool.parsers.python.PythonParser" -> "python"
+        module_name = value[0].__module__
+        language = module_name.split(".")[-1]
+        if language not in language_files:
+            language_files[language] = []
+        language_files[language].append(key)
+
+    return language_files, file_checkers
+
+
 def find_files(root_dir: str) -> list[str]:
     """
     Find all language files that CVE-bin-tool scans
@@ -41,19 +76,19 @@ def find_files(root_dir: str) -> list[str]:
     matches: list[str]
         A list of paths to metadata files for language packages
     """
-    valid_files = cbt_valid_files.copy()
-    valid_files["METADATA"] = valid_files["METADATA: "]
-    valid_files["PKG-INFO"] = valid_files["PKG-INFO: "]
 
-    matches = []
-    for dirpath, dirnames, filenames in os.walk(root_dir):
-        for filename in filenames:
-            if filename in valid_files and filename != "requirements.txt":
-                matches.append((f"{dirpath}/{filename}", valid_files[filename]))
+    matches = {}
+    language_files, file_checkers = list_language_files()
+    for language in language_files:
+        matches[language] = []
+        for dirpath, _, filenames in os.walk(root_dir):
+            for filename in filenames:
+                if filename in language_files[language] and filename != "requirements.txt":
+                    matches[language].append((f"{dirpath}/{filename}", file_checkers[filename]))
     return matches
 
 
-def write_package_csv(rootfs: str) -> None:
+def write_language_csvs(rootfs: str, language_files: List[str]) -> None:
     """
     Write a CSV file of all language packages found
 
@@ -65,21 +100,23 @@ def write_package_csv(rootfs: str) -> None:
     cve_db = CVEDB()
     logger = LOGGER.getChild("Fuzz")
 
-    files = find_files(rootfs)
-    print(f"Found {len(files)} Language Files")
+    print(f"Collecting product, vendor and version information from language files...")
+    for language, file_list in language_files.items():
+        if len(file_list) > 0:
+            print(f"Found {len(file_list)} Language Files ({language})")
 
-    with open(f"{CVE_DIR}/lang-packages.csv", "w") as f:
-        f.write("vendor,product,version\n")
-        for file, parserclslist in files:
-            for parsercls in parserclslist:
-                parser = parsercls(cve_db, logger)
+            with open(f"{CVE_DIR}/lang-{language}-packages.csv", "w") as f:
+                f.write("vendor,product,version\n")
+                for file, parserclslist in file_list:
+                    for parsercls in parserclslist:
+                        parser = parsercls(cve_db, logger)
 
-                output = parser.run_checker(file)
-                for out in output:
-                    items = (out.product_info.vendor, out.product_info.product, out.product_info.version)
-                    f.write(f"{','.join(items)}\n")
+                        output = parser.run_checker(file)
+                        for out in output:
+                            items = (out.product_info.vendor, out.product_info.product, out.product_info.version)
+                            f.write(f"{','.join(items)}\n")
 
-    print("Saved lang-packages.csv")
+                print(f"Saved lang-{language}-packages.csv")
 
     # cve_db does unusual things when it exists, so let's catch it
     try:
@@ -88,19 +125,34 @@ def write_package_csv(rootfs: str) -> None:
         pass
 
 
-def run_scan() -> None:
+def run_language_scan(language: str) -> str:
     """
     Scan the CVE database using the list of language packages found and save the
     results to a JSON file.
+
+    Inputs
+    =======
+    language: str
+        The name of the programming language to scan (e.g., "python", "ruby", "nodejs", etc.)
+    
+    Returns
+    =======
+    str
+        The path to the JSON file containing the CVE scan results for the language packages.
+        If the file does not exist, an empty string is returned.
     """
 
-    print("Scanning Language Packages")
+    print(f"Scanning Language Packages ({language})...")
+    fname = f"{CVE_DIR}/lang-{language}-packages.csv"
+    if not os.path.exists(fname):
+        print(f"File {fname} does not exist. Skipping scan for {language}.")
+        return ""
     cmd = [
         "cve-bin-tool",
         "-u", "never",       # Never update the local CVE database
         "-f", "json",        # Output format: JSON
-        "-o", f"{CVE_DIR}/cve-bin-tool-lang-summary.json",   # Write JSON results to this file
-        "-i", f"{CVE_DIR}/lang-packages.csv"
+        "-o", f"{CVE_DIR}/cve-bin-tool-lang-{language}-summary.json",   # Write JSON results to this file
+        "-i", fname
     ]
     _ = subprocess.run(
         cmd,
@@ -110,15 +162,45 @@ def run_scan() -> None:
     )
     # do not try to do anything clever with the result.returncode here, because
     # it only ever returns 0 if there are 0 vulnerabilities!
+    return fname
 
+
+def scan_languages(languages) -> None:
+    """
+    Scan all languages found in the root filesystem for CVEs.
+
+    Inputs
+    =======
+    languages: list[str]
+        A list of programming languages to scan (e.g., ["python", "ruby", "nodejs", ...])
+
+    """
+
+    cve_files = []
+    for language in languages:
+        cve_file = run_language_scan(language)
+        if cve_file:
+            cve_files.append(cve_file)
+
+    # collect all the results into a single file
+    print("Collecting all results into a single file...")
+    cve_data = []
+    for file in cve_files:
+        with open(file, "r") as f:
+            data = json.load(f)
+            cve_data.extend(data)
+
+    with open(f"{CVE_DIR}/cve-bin-tool-lang-summary.json", "w") as f:
+        json.dump(cve_data, f, indent=2)
+        
 
 def main(rootfs: str) -> None:
     """
     Scan the root filesystem for CVEs in the language packages.
     """
-
-    write_package_csv(rootfs)
-    run_scan()
+    language_files = find_files(rootfs)
+    write_language_csvs(rootfs, language_files)
+    scan_languages(list(language_files.keys()))
 
 
 if __name__ == "__main__":

--- a/scripts/triage.json
+++ b/scripts/triage.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:31a16ccf-d8ad-4cf1-995b-304845c3baf9",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-07-03T17:31:28Z",
+    "tools": {
+      "components": [
+        {
+          "name": "lib4vex",
+          "version": "0.2.0",
+          "type": "application"
+        }
+      ]
+    },
+    "properties": [
+      {
+        "name": "Revision_1",
+        "value": "Initial version"
+      }
+    ],
+    "component": {
+      "type": "application",
+      "supplier": {
+        "name": "jmespath_project"
+      },
+      "version": "1.0.1",
+      "bom-ref": "CDXRef-DOCUMENT",
+      "name": "jmespath"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "bom-ref": "jmespath@1.0.1",
+      "id": "CVE-2022-32511",
+      "source": {
+        "name": "NVD",
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-32511"
+      },
+      "description": "jmespath.rb (aka JMESPath for Ruby) before 1.6.1 uses JSON.load in a situation where JSON.parse is preferable.",
+      "published": "2025-07-03T17:31:28Z",
+      "updated": "2025-07-03T17:31:28Z",
+      "analysis": {
+        "state": "not_affected",
+        "detail": ""
+      },
+      "affects": [
+        {
+          "ref": "urn:cbt:1/jmespath_project#jmespath:1.0.1"
+        }
+      ],
+      "properties": [
+        {
+          "name": "bom_link",
+          "value": "urn:cbt:1/jmespath_project#jmespath:1.0.1"
+        },
+        {
+          "name": "source",
+          "value": "NVD"
+        },
+        {
+          "name": "updated",
+          "value": ""
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
`cve-bin-tool` uses the `product`, `vendor` and `version` of a language package (e.g. `JMESpath` in this case) to check if there is a corresponding vulnerability within its database. The issue with this is that `JMESpath` has multiple packages for different languages, where their versions are not aligned and there is no differentiation between them in the CVE database. This means that the critical CVE which affects the Ruby version of `JMESpath` for versions `< 1.6.1` is flagged for the latest, unaffected Python package version `1.0.1`. The "solution" here is to triage that particular package so that it does not appear in the output of the CVE scanner.
