### PR TITLE
Implement duplicate `date.py` functions from Memgraph

### DIFF
--- a/e2e/date_test/test_convert_format/test.yml
+++ b/e2e/date_test/test_convert_format/test.yml
@@ -1,0 +1,112 @@
+# TODO(colinbarry) Duplicate of tests for Memgrraph/query_modules/date.py. We
+# needed to implement this in both places as GraphQL w MAGE support requires
+# `date.convert_format`.
+query: >-
+    RETURN date.convert_format('2011-12-03T10:15:30+01:00[Europe/Paris]', 'iso_zoned_date_time', 'iso_offset_date_time') AS output;
+output:
+  - output: "2011-12-03T10:15:30+01:00"
+
+query: >-
+    RETURN date.convert_format('2011-12-03T10:15:30+01:00', 'iso_offset_date_time', 'iso_zoned_date_time') AS output;
+output:
+  - output: "2011-12-03T10:15:30+01:00"
+
+query: >-
+    RETURN date.convert_format('20111203', 'basic_iso_date', 'iso_local_date') AS output;
+output:
+  - output: "2011-12-03"
+
+query: >-
+    RETURN date.convert_format('2011-12-03', 'iso_local_date', 'basic_iso_date') AS output;
+output:
+  - output: "20111203"
+
+query: >-
+  RETURN date.convert_format('2011-12-03+01:00', 'iso_offset_date', 'iso_local_date') AS output;
+output:
+  - output: "2011-12-03"
+
+query: >-
+  RETURN date.convert_format('2011-12-03+01:00', 'iso_offset_date', 'basic_iso_date') AS output;
+output:
+  - output: "20111203"
+
+query: >-
+  RETURN date.convert_format('10:15:30', 'iso_local_time', 'iso_offset_time') AS output;
+output:
+  - output: "10:15:30+00:00"
+
+query: >-
+  RETURN date.convert_format('10:15:30+01:00', 'iso_offset_time', 'iso_local_time') AS output;
+output:
+  - output: "10:15:30"
+
+query: >-
+  RETURN date.convert_format('2011-12-03T10:15:30', 'iso_local_date_time', 'iso_local_date') AS output;
+output:
+  - output: "2011-12-03"
+
+query: >-
+  RETURN date.convert_format('2011-12-03T10:15:30', 'iso_local_date_time', 'iso_local_time') AS output;
+output:
+  - output: "10:15:30"
+
+query: >-
+  RETURN date.convert_format('2011-12-03T10:15:30', 'iso_local_date_time', 'basic_iso_date') AS output;
+output:
+  - output: "20111203"
+
+query: >-
+  RETURN date.convert_format('2011-12-03T10:15:30+01:00', 'iso_offset_date_time', 'iso_local_date_time') AS output;
+output:
+  - output: "2011-12-03T10:15:30"
+
+query: >-
+  RETURN date.convert_format('2011-12-03T10:15:30+01:00', 'iso_offset_date_time', 'iso_offset_date') AS output;
+output:
+  - output: "2011-12-03+01:00"
+
+query: >-
+  RETURN date.convert_format('2011-12-03T10:15:30+01:00', 'iso_offset_date_time', 'iso_offset_time') AS output;
+output:
+  - output: "10:15:30+01:00"
+
+query: >-
+  RETURN date.convert_format('2011-12-03T10:15:30+01:00[Europe/Paris]', 'iso_zoned_date_time', 'iso_local_date') AS output;
+output:
+  - output: "2011-12-03"
+
+query: >-
+  RETURN date.convert_format('2011-12-03T10:15:30+01:00[Europe/Paris]', 'iso_zoned_date_time', 'iso_local_date_time') AS output;
+output:
+  - output: "2011-12-03T10:15:30"
+
+query: >-
+  RETURN date.convert_format('2011-12-03T10:15:30+01:00[Europe/Paris]', 'iso_zoned_date_time', 'basic_iso_date') AS output;
+output:
+  - output: "20111203"
+
+query: >-
+  RETURN date.convert_format('2011-12-03', 'iso_date', 'basic_iso_date') AS output;
+output:
+  - output: "20111203"
+
+query: >-
+  RETURN date.convert_format('2011-12-03+01:00', 'iso_date', 'iso_local_date') AS output;
+output:
+  - output: "2011-12-03"
+
+query: >-
+  RETURN date.convert_format('10:15:30+01:00', 'iso_time', 'iso_offset_time') AS output;
+output:
+  - output: "10:15:30+01:00"
+
+query: >-
+  RETURN date.convert_format('20111203', 'basic_iso_date', 'iso_offset_date') AS output;
+output:
+  - output: "2011-12-03+00:00"
+
+query: >-
+  RETURN date.convert_format('2011-12-03T10:15:30', 'iso_local_date_time', 'iso_offset_date_time') AS output;
+output:
+  - output: "2011-12-03T10:15:30+00:00"

--- a/python/date.py
+++ b/python/date.py
@@ -1,6 +1,8 @@
 import mgp
 import pytz
 import datetime
+from enum import IntEnum
+from zoneinfo import ZoneInfo
 
 from mage.date.constants import Conversion, Epoch
 from mage.date.unit_conversion import to_int, to_timedelta
@@ -138,16 +140,14 @@ def add(
         unit=unit,
     )
 
-# TODO(colinbarry) Code below is a copy and paste from `date.py` in the Memgraph
+# TODO(colinbarry) Code below is a copy and paste from `date.py` in the Memgraph
 # repo. This is a temporary fix to make it possible to use `date.convert_format`
 # from the Memgraph+MAGE image; otherwise, MAGE's `date.py` will overwrite the
 # Memgraph one, and users would lose the function. As the function is needed
-# by GraphQL, and it seems some users are wanting to use GraphQL + MAGE, this 
+# by GraphQL, and it seems some users are wanting to use GraphQL + MAGE, this
 # seems the best approach for now. At some point, we will be moving to a
 # monorepo, and the code below and tests in `date_test/test_convert_format` can
 # be removed in favour of the copy in the Memgraph repo.
-from enum import IntEnum
-from zoneinfo import ZoneInfo
 
 
 class FormatLength(IntEnum):
@@ -188,7 +188,7 @@ class DateFormatUtil:
 
 
 @mgp.function
-def convert_format(temporal: str, current_format: str, convert_to: str) -> mgp.Nullable[str]:
+def convert_format(temporal: str, current_format: str, convert_to: str) -> mgp.Nullable[str]:  # noqa: C901
     """
     Converts between specified ISO date formats using Python strftime and strptime.
     Supports zoned to offset conversion by removing zone part in '[]'.

--- a/python/date.py
+++ b/python/date.py
@@ -137,3 +137,155 @@ def add(
         + to_timedelta(time=add_value, unit=add_unit),
         unit=unit,
     )
+
+# TODO(colinbarry) Code below is a copy and paste from `date.py` in the Memgraph
+# repo. This is a temporary fix to make it possible to use `date.convert_format`
+# from the Memgraph+MAGE image; otherwise, MAGE's `date.py` will overwrite the
+# Memgraph one, and users would lose the function. As the function is needed
+# by GraphQL, and it seems some users are wanting to use GraphQL + MAGE, this 
+# seems the best approach for now. At some point, we will be moving to a
+# monorepo, and the code below and tests in `date_test/test_convert_format` can
+# be removed in favour of the copy in the Memgraph repo.
+from enum import IntEnum
+from zoneinfo import ZoneInfo
+
+
+class FormatLength(IntEnum):
+    """Enum for various date/time format lengths to replace magic numbers"""
+
+    DATE = 10  # Length of 'YYYY-MM-DD'
+    TIME = 8  # Length of 'HH:MM:SS'
+    OFFSET = 5  # Length of '+hhmm' or '-hhmm'
+
+
+class DateFormatUtil:
+    """
+    Utility class for converting between predefined ISO date formats using Python strftime and strptime.
+    """
+
+    ISO_DATE_FORMATS = {
+        "basic_iso_date": "%Y%m%d",  # BASIC_ISO_DATE: '20111203'
+        "iso_local_date": "%Y-%m-%d",  # ISO_LOCAL_DATE: '2011-12-03'
+        "iso_offset_date": "%Y-%m-%d%z",  # ISO_OFFSET_DATE: '2011-12-03+01:00'
+        "iso_date": "%Y-%m-%d",  # ISO_DATE: '2011-12-03' or '2011-12-03+01:00' (handled separately)
+        "iso_local_time": "%H:%M:%S",  # ISO_LOCAL_TIME: '10:15:30'
+        "iso_offset_time": "%H:%M:%S%z",  # ISO_OFFSET_TIME: '10:15:30+01:00'
+        "iso_time": "%H:%M:%S",  # ISO_TIME: '10:15:30' or '10:15:30+01:00' (handled separately)
+        "iso_local_date_time": "%Y-%m-%dT%H:%M:%S",  # ISO_LOCAL_DATE_TIME: '2011-12-03T10:15:30'
+        "iso_offset_date_time": "%Y-%m-%dT%H:%M:%S%z",  # ISO_OFFSET_DATE_TIME: '2011-12-03T10:15:30+01:00'
+        "iso_zoned_date_time": "iso_zoned_date_time",  # Special case
+        "iso_date_time": "%Y-%m-%dT%H:%M:%S",  # ISO_DATE_TIME: '2011-12-03T10:15:30+01:00[Europe/Paris]' handled as zoned
+    }
+
+    @staticmethod
+    def get_format(format_str: str) -> str:
+        format_lower = format_str.lower()
+        if format_lower == "iso_zoned_date_time" or format_lower == "iso_date_time":
+            return "iso_zoned_date_time"
+        if format_lower not in DateFormatUtil.ISO_DATE_FORMATS:
+            raise ValueError(f"Unsupported date format: {format_str}")
+        return DateFormatUtil.ISO_DATE_FORMATS[format_lower]
+
+
+@mgp.function
+def convert_format(temporal: str, current_format: str, convert_to: str) -> mgp.Nullable[str]:
+    """
+    Converts between specified ISO date formats using Python strftime and strptime.
+    Supports zoned to offset conversion by removing zone part in '[]'.
+    Offset to zoned returns the same string.
+    Throws if parsing fails.
+
+    Args:
+        temporal: The datetime string to convert
+        current_format: The current format of the datetime string
+        convert_to: The target format to convert to
+
+    Returns:
+        output: The converted datetime string or None if input is None or empty
+    """
+    if temporal is None or temporal.strip() == "":
+        return None
+
+    try:
+        current_formatter = DateFormatUtil.get_format(current_format)
+        convert_to_formatter = DateFormatUtil.get_format(convert_to)
+
+        # Parse input string
+        if current_formatter == "iso_zoned_date_time":
+            # Remove zone part in [] and parse
+            temporal_without_zone = temporal.split("[")[0]
+            dt = datetime.datetime.strptime(temporal_without_zone, "%Y-%m-%dT%H:%M:%S%z")
+        elif current_format.lower() == "iso_date":
+            # iso_date can have optional offset, try parsing with offset first
+            try:
+                dt = datetime.datetime.strptime(temporal, "%Y-%m-%d%z")
+            except ValueError:
+                dt = datetime.datetime.strptime(temporal, "%Y-%m-%d")
+        elif current_format.lower() == "iso_time":
+            # iso_time can have optional offset
+            try:
+                dt = datetime.datetime.strptime(temporal, "%H:%M:%S%z")
+            except ValueError:
+                dt = datetime.datetime.strptime(temporal, "%H:%M:%S")
+        else:
+            # Standard parsing for all other formats
+            dt = datetime.datetime.strptime(temporal, current_formatter)
+
+        # Convert to target format
+        if convert_to_formatter == "iso_zoned_date_time":
+            # Converting to zoned date time: return offset datetime string (no zone name)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=ZoneInfo("UTC"))
+            naive_part = dt.strftime("%Y-%m-%dT%H:%M:%S")
+            offset = dt.strftime("%z")
+            # Format offset as +hh:mm
+            if len(offset) == FormatLength.OFFSET:
+                offset = f"{offset[:3]}:{offset[3:]}"
+            converted = f"{naive_part}{offset}"
+        elif convert_to.lower() == "iso_date":
+            # iso_date: include offset if timezone info is present
+            if dt.tzinfo is not None:
+                converted = dt.strftime("%Y-%m-%d%z")
+                # Format offset as +hh:mm
+                if len(converted) > FormatLength.DATE:
+                    converted = f"{converted[:-2]}:{converted[-2:]}"
+            else:
+                converted = dt.strftime("%Y-%m-%d")
+        elif convert_to.lower() == "iso_time":
+            # iso_time: include offset if timezone info is present
+            if dt.tzinfo is not None:
+                converted = dt.strftime("%H:%M:%S%z")
+                # Format offset as +hh:mm
+                if len(converted) > FormatLength.TIME:
+                    converted = f"{converted[:-2]}:{converted[-2:]}"
+            else:
+                converted = dt.strftime("%H:%M:%S")
+        else:
+            # For offset formats, ensure timezone is present
+            if convert_to_formatter.endswith("%z") and dt.tzinfo is None:
+                dt = dt.replace(tzinfo=ZoneInfo("UTC"))
+            # For local formats, remove timezone info
+            elif not convert_to_formatter.endswith("%z") and dt.tzinfo is not None:
+                dt = dt.replace(tzinfo=None)
+
+            converted = dt.strftime(convert_to_formatter)
+
+            # Format offset as +hh:mm for offset formats
+            if convert_to_formatter.endswith("%z") and len(converted) > FormatLength.DATE:
+                converted = f"{converted[:-2]}:{converted[-2:]}"
+
+        return converted
+
+    except Exception as e:
+        raise Exception(f"Error converting '{temporal}' from '{current_format}' to '{convert_to}': {e}")
+
+
+@mgp.read_proc
+def get_date_formats(context: mgp.ProcCtx) -> mgp.Record(formats=mgp.List[str]):
+    """
+    Returns a list of supported date formats.
+
+    Returns:
+        formats: List of supported date formats
+    """
+    return mgp.Record(formats=list(DateFormatUtil.ISO_DATE_FORMATS.keys()))


### PR DESCRIPTION
### Description

GraphQL support needs `date.convert_format`, currently implemented in Memgraph's `query_modules`. When we build the Memgraph+MAGE image, MAGE's `date.py` overwrites Memgraph's. As there is no way to separate filename from the function's namespace, the best solution (for now) is to duplicate the code and tests here. When we combine both in a monorepo, the duplicated code can be removed.

### Pull request type

- [ ] Bugfix
- [ ] Algorithm/Module
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Tests provided (unit / e2e)
- [ ] Code documentation
- [ ] README short description


### Documentation checklist
- [ ] Add the documentation label tag
- [ ] Add the bug / feature label tag
- [ ] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [ ] Write a release note, including added/changed clauses
    - **[Release note text]**
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
