### PR TITLE
fix: cve-bin-tool OSV update

### DIFF
--- a/.github/workflows/update_cve_database.yml
+++ b/.github/workflows/update_cve_database.yml
@@ -41,7 +41,9 @@ jobs:
           retry_wait_seconds: 300
           command: |
             source "${{ env.CVE_DIR }}/env/bin/activate"
-            python3 scripts/update_cve_db.py
+
+            # cve-bin-tool returns a non-zero exit code if it is not given anything to scan
+            cve-bin-tool -u now || true
             
             # Wait for the update to complete and compress the database
             cd ~/.cache/cve-bin-tool

--- a/.github/workflows/update_cve_database.yml
+++ b/.github/workflows/update_cve_database.yml
@@ -27,7 +27,11 @@ jobs:
           python3 -m venv "${{ env.CVE_DIR }}/env"
           source "${{ env.CVE_DIR }}/env/bin/activate"
           python -m pip install --upgrade pip
-          pip install cve-bin-tool==3.4
+          
+          # pip install cve-bin-tool==3.4
+          # Install my personal fork of cve-bin-tool with fix to the OSV issue
+          # TODO: Once version 3.4.1 is released, check if https://github.com/intel/cve-bin-tool/pull/5240 is merged
+          pip install git+https://github.com/mattkjames7/cve-bin-tool.git@fix-osv-update
 
       - name: Update CVE database
         uses: nick-fields/retry@v3


### PR DESCRIPTION
`cve-bin-tool` fails to update it's database with open-source vulnerabilities due to a key error. I have fixed this in my personal fork of `cve-bin-tool`, so we can install that for now until the fix is made in a new release.

