### PR TITLE
Disable cve-bin-tool on weekly CVE scan

### DIFF
--- a/.github/workflows/cve_scan.yml
+++ b/.github/workflows/cve_scan.yml
@@ -88,5 +88,5 @@ jobs:
       image_type: ${{ matrix.image_type }}
       run_trivy: true
       run_grype: true
-      run_cbt: true
+      run_cbt: false  # TODO: enable cve-bin-tool database update job if re-enabled by default
     secrets: inherit

--- a/.github/workflows/update_cve_database.yml
+++ b/.github/workflows/update_cve_database.yml
@@ -1,8 +1,9 @@
 name: Update CVE Database
 on:
-  schedule:
-    # Run at 1 AM UTC on Saturday
-    - cron: '0 1 * * 6'
+  # NOTE: disabled for now, will be re-enabled when cve-bin-tool is re-enabled by default
+  # schedule:
+  #   # Run at 1 AM UTC on Saturday
+  #   - cron: '0 1 * * 6'
   workflow_dispatch:  # Allow manual triggering
 
 jobs:


### PR DESCRIPTION
`cve-bin-tool` is a source of a lot of false positives and flakiness. Let's disable it for now, until their issues are fixed.

