### PR TITLE
Use retry logic with curl

### DIFF
--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -231,7 +231,7 @@ jobs:
 
 
       - name: Download memgraph binary
-        run: curl -L ${{ env.MEMGRAPH_DOWNLOAD_LINK }} > memgraph-${{ inputs.arch }}.deb
+        run: curl -L --retry 5 --retry-delay 20 --retry-max-time 120 ${{ env.MEMGRAPH_DOWNLOAD_LINK }} > memgraph-${{ inputs.arch }}.deb
 
       - name: Probe fastest mirror
         run: |

--- a/.github/workflows/reusable_test.yml
+++ b/.github/workflows/reusable_test.yml
@@ -176,7 +176,7 @@ jobs:
 
       - name: Download memgraph binary (Object URL)
         if: env.MEMGRAPH_OBJECT_URL
-        run: curl -L ${{ env.MEMGRAPH_OBJECT_URL }} > memgraph-${{ inputs.arch }}.deb
+        run: curl -L --retry 5 --retry-delay 20 --retry-max-time 120 ${{ env.MEMGRAPH_OBJECT_URL }} > memgraph-${{ inputs.arch }}.deb
       
       - name: Setup AWS credentials
         if: env.MEMGRAPH_S3_URI


### PR DESCRIPTION
Downloading the Memgraph binary sometimes fails during the daily build, so let's try the `--retry` option built into `curl`.
