### PR TITLE
Ensure migration connections are closed

### DIFF
--- a/python/migrate.py
+++ b/python/migrate.py
@@ -797,8 +797,8 @@ def cleanup_migrate_memgraph():
 
     thread_id = threading.get_native_id()
     if Constants.CONNECTION in memgraph_dict[thread_id]:
-        memgraph_dict[threading.get_native_id][Constants.CONNECTION].close()
-    memgraph_dict.pop(threading.get_native_id, None)
+        memgraph_dict[thread_id][Constants.CONNECTION].close()
+    memgraph_dict.pop(thread_id, None)
 
 
 mgp.add_batch_read_proc(memgraph, init_migrate_memgraph, cleanup_migrate_memgraph)


### PR DESCRIPTION
### Description

Fixes an issue where migration connections are not closed in clean-up because of the incorrect thread handle being used.

### Pull request type

- [x] Bugfix
- [ ] Algorithm/Module
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Related issues

Delete if this PR doesn't resolve any issues. Link the issue if it does.

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [x] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Tests provided (unit / e2e)
- [ ] Code documentation
- [ ] README short description


### Documentation checklist
- [ ] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - Fixed: Correctly close database connections after migrations are completed.
- [ ] Link the documentation PR here
    - **[Documentation PR link]**
