### PR TITLE
Remove unnecessary DEB builds

### DIFF
--- a/.github/workflows/reusable_package_mage.yaml
+++ b/.github/workflows/reusable_package_mage.yaml
@@ -126,7 +126,7 @@ jobs:
           elif [[ "$INPUT_PACKAGE_DEB" == "false" ]]; then
             package_deb=false
           else
-            if [[ "$CUDA" == true || "$MALLOC" == true ]]; then
+            if [[ "$MALLOC" == true ]]; then
               package_deb=false
             else
               package_deb=true


### PR DESCRIPTION
We are building a few too many duplicate DEB packages, we should only build:
1. `x86_64` + `Release`
2. `x86_64` + `RelWithDebInfo`
3. `aarch64` + `Release`
4. `aarch64` + `RelWithDebInfo`
5. `x86_64` + `RelWithDebInfo` + CUDA (this has a subtly different installer)
All `-malloc` builds are the same as the non-malloc builds.
