### PR TITLE
Add script to run Memgraph within gdb

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -116,7 +116,7 @@ RUN if [ -n "$CUSTOM_MIRROR" ]; then \
     fi
 
 # Copy script from Memgraph repo to run Memgraph with GDB - override the entrypoint to use it
-COPY cpp/memgraph/tools/run_with_gdb.sh /usr/lib/memgraph/run_with_gdb.sh
+COPY cpp/memgraph/release/docker/run_with_gdb.sh /usr/lib/memgraph/run_with_gdb.sh
 
 USER memgraph
 EXPOSE 7687


### PR DESCRIPTION
Added script to `relwithdebinfo` Docker image that can be used to run Memgraph in `gdb`.

Example usage:

```bash
# create a directory with sufficient permissions to save the core on the host
mkdir -p cores
chmod 777 cores

# run memgraph via the debug script by overriding the entry point, and creating a bind mount for the core dump
docker run --rm \
  --name memgraph \
  -v "$(pwd)/cores:/tmp/cores" \
  --entrypoint /usr/lib/memgraph/run_with_gdb.sh \
  -p 7687:7687 \
  memgraph/memgraph:3.6.0_67_769f09ec3744-relwithdebinfo
```

Optionally override `$CORE_PATH` with the path to the core dump, e.g.
```bash
docker run --rm \
  --name memgraph \
  -v "$(pwd)/cores:/some/other/dir/cores" \
  -e CORE_PATH=/some/other/dir/cores/cure.dump \
  --entrypoint /usr/lib/memgraph/run_with_gdb.sh \
  -p 7687:7687 \
  memgraph/memgraph:3.6.0_67_769f09ec3744-relwithdebinfo
```



If Memgraph crashes, a full backtrace will be printed in the terminal. To simulate this:

```bash
docker exec memgraph bash -c "kill -SIGINT \$(pidof memgraph)"
```
