### PR TITLE
Skip tests on push to external PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
           echo "DEBUG: binary_name_base=memgraph_${memgraph_version}-1"
 
   PR_test:
-    if: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.TestVariables.outputs.run_tests == 'true' }}
+    if: ${{ (github.event_name == 'pull_request' && needs.TestVariables.outputs.run_tests == 'true') || github.event_name == 'merge_group' }}
     needs: [TestVariables]
     strategy:
       fail-fast: false


### PR DESCRIPTION
In order to be able to add external PRs to the merge queue, checks need to pass first. This cannot happen in the test set-up step because it requires AWS secrets to be able to determine things such as the memgraph and mage versions.

This work around should allow the test set-up to "pass" but not trigger the test runs themselves when pushing to a PR. The result of this is that the check should either pass or skip, but not fail. If this works then, when added to the merge queue, the workflows should run with access to secrets (and here the tests _will_ run).

