### PR TITLE
fix: migrate.py issues with the new scheduler

### DIFF
--- a/python/migrate.py
+++ b/python/migrate.py
@@ -242,6 +242,9 @@ def sql_server(
     """
     global sql_server_dict
 
+    if not params:
+        params = []
+
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)
 
@@ -472,6 +475,9 @@ def postgresql(
     :return: The result table as a stream of rows
     """
     global postgres_dict
+
+    if not params:
+        params = []
 
     if len(config_path) > 0:
         config = _combine_config(config=config, config_path=config_path)


### PR DESCRIPTION
### Description

Each batch run inside the migrate.py module could be called from a different thread (due to new scheduler) which would cause it to fail due to relying on thread id.

### Pull request type

- [x] Bugfix
- [ ] Algorithm/Module
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Related issues

closes #712 

######################################

### Reviewer checklist (the reviewer checks this part)
#### Module/Algorithm
- [ ] Core algorithm/module implementation
- [ ] [Query module](https://memgraph.com/docs/memgraph/reference-guide/query-modules) implementation
- [ ] Tests provided (unit / e2e)
- [ ] Code documentation
- [ ] README short description


### Documentation checklist
- [x] Add the documentation label tag
- [x] Add the bug / feature label tag
- [x] Add the milestone for which this feature is intended
    - If not known, set for a later milestone
- [x] Write a release note, including added/changed clauses
    - **Fix an issue where the migrate module would fail if returning more than 1000 results. [#711](https://github.com/memgraph/mage/pull/711)**
- [x] Link the documentation PR here
    - **[Documentation PR link]**
